### PR TITLE
Chore/fix sync bug multiple depedent changes

### DIFF
--- a/src/SIL.Harmony.Sample/Changes/SetDefinitionPartOfSpeechChange.cs
+++ b/src/SIL.Harmony.Sample/Changes/SetDefinitionPartOfSpeechChange.cs
@@ -1,0 +1,16 @@
+using SIL.Harmony.Changes;
+using SIL.Harmony.Entities;
+using SIL.Harmony.Sample.Models;
+
+namespace SIL.Harmony.Sample.Changes;
+
+public class SetDefinitionPartOfSpeechChange(Guid entityId, string partOfSpeech) : EditChange<Definition>(entityId), ISelfNamedType<SetDefinitionPartOfSpeechChange>
+{
+    public string PartOfSpeech { get; } = partOfSpeech;
+
+    public override ValueTask ApplyChange(Definition entity, ChangeContext context)
+    {
+        entity.PartOfSpeech = PartOfSpeech;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
+++ b/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
@@ -45,13 +45,20 @@ public static class CrdtSampleKernel
                 .Add<SetWordNoteChange>()
                 .Add<AddAntonymReferenceChange>()
                 .Add<SetOrderChange<Definition>>()
+                .Add<SetDefinitionPartOfSpeechChange>()
                 .Add<DeleteChange<Word>>()
                 .Add<DeleteChange<Definition>>()
                 .Add<DeleteChange<Example>>()
                 ;
             config.ObjectTypeListBuilder.DefaultAdapter()
                 .Add<Word>()
-                .Add<Definition>()
+                .Add<Definition>(builder =>
+                {
+                    builder.HasOne<Word>()
+                        .WithMany()
+                        .HasForeignKey(d => d.WordId)
+                        .OnDelete(DeleteBehavior.Cascade);
+                })
                 .Add<Example>();
         });
         return services;

--- a/src/SIL.Harmony.Tests/DataModelPerformanceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelPerformanceTests.cs
@@ -31,7 +31,7 @@ public class DataModelPerformanceTests(ITestOutputHelper output)
             );
         foreach (var benchmarkCase in summary.BenchmarksCases.Where(b => !summary.IsBaseline(b)))
         {
-            var ratio = double.Parse(BaselineRatioColumn.RatioMean.GetValue(summary, benchmarkCase));
+            var ratio = double.Parse(BaselineRatioColumn.RatioMean.GetValue(summary, benchmarkCase), System.Globalization.CultureInfo.InvariantCulture);
             //for now it just makes sure that no case is worse that 7x, this is based on the 10_000 test being 5 times worse.
             //it would be better to have this scale off the number of changes
             ratio.Should().BeInRange(0, 7, "performance should not get worse, benchmark " + benchmarkCase.DisplayInfo);

--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -90,13 +90,15 @@
       PartOfSpeech (string) Required
       SnapshotId (no field, Guid?) Shadow FK Index
       Text (string) Required
-      WordId (Guid) Required
+      WordId (Guid) Required FK Index
     Keys: 
       Id PK
     Foreign keys: 
       Definition {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
+      Definition {'WordId'} -> Word {'Id'} Required Cascade
     Indexes: 
       SnapshotId Unique
+      WordId
     Annotations: 
       DiscriminatorProperty: 
       Relational:FunctionName: 

--- a/src/SIL.Harmony.Tests/SyncTests.cs
+++ b/src/SIL.Harmony.Tests/SyncTests.cs
@@ -100,7 +100,7 @@ public class SyncTests : IAsyncLifetime
                 var clientSnapshot = await client.DataModel.GetProjectSnapshot();
                 var simpleSnapshot = clientSnapshot.Snapshots.Should().ContainKey(entitySnapshot.EntityId).WhoseValue;
                 var entity = await client.DataModel.GetBySnapshotId<Word>(simpleSnapshot.Id);
-                  entity.Should().BeEquivalentTo(serverEntity);
+                entity.Should().BeEquivalentTo(serverEntity);
             }
         }
     }


### PR DESCRIPTION
During a sync, if a word is created, then a definition is created, and there's more than one change to that definition, and all 3+ of those changes come via a sync at once there will be a failure due to a FK constraint, I suspect this is due to the creation of the definition happening before the word is created.