### PR TITLE
don't return tracked objects from the dbContext to avoid clients modifying objects which EF tracks

### DIFF
--- a/src/SIL.Harmony.Core/QueryHelpers.cs
+++ b/src/SIL.Harmony.Core/QueryHelpers.cs
@@ -6,7 +6,7 @@ public static class QueryHelpers
 {
     public static async Task<SyncState> GetSyncState(this IQueryable<CommitBase> commits)
     {
-        var dict = await commits.GroupBy(c => c.ClientId)
+        var dict = await commits.AsNoTracking().GroupBy(c => c.ClientId)
             .Select(g => new { ClientId = g.Key, DateTime = g.Max(c => c.HybridDateTime.DateTime) })
             .AsAsyncEnumerable()//this is so the ticks are calculated server side instead of the db
             .ToDictionaryAsync(c => c.ClientId, c => c.DateTime.ToUnixTimeMilliseconds());

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -194,7 +194,7 @@ internal class CrdtRepository
     {
         if (_crdtConfig.Value.EnableProjectedTables)
         {
-            return _dbContext.Set<T>();
+            return _dbContext.Set<T>().AsNoTracking();
         }
         throw new NotSupportedException("GetCurrentObjects is not supported when not using projected tables");
     }


### PR DESCRIPTION
in the future we can probably make this more systematic so new apis don't have to think about exposing tracked objects, but this patches the existing holes we have