### PR TITLE
expose GetObjectsReferencing in ChangeContext

### DIFF
--- a/src/SIL.Harmony.Tests/ConfigTests.cs
+++ b/src/SIL.Harmony.Tests/ConfigTests.cs
@@ -1,0 +1,32 @@
+using SIL.Harmony.Sample.Changes;
+using SIL.Harmony.Sample.Models;
+using SIL.Harmony.Tests.Adapter;
+
+namespace SIL.Harmony.Tests;
+
+public class ConfigTests
+{
+    [Fact]
+    public void CanGetEntityTypes()
+    {
+        var config = new CrdtConfig();
+        config.ObjectTypeListBuilder.DefaultAdapter()
+            .Add<Word>()
+            .Add<Definition>();
+        config.ObjectTypeListBuilder
+            .CustomAdapter<CustomObjectAdapterTests.IMyCustomInterface, CustomObjectAdapterTests.MyClassAdapter>()
+            .Add<CustomObjectAdapterTests.MyClass>();
+        var types = config.ObjectTypes.ToArray();
+        types.Should().BeEquivalentTo([typeof(Word), typeof(Definition), typeof(CustomObjectAdapterTests.MyClass)]);
+    }
+
+    [Fact]
+    public void CanGetChangeTypes()
+    {
+        var config = new CrdtConfig();
+        config.ChangeTypeListBuilder.Add<NewDefinitionChange>();
+        config.ChangeTypeListBuilder.Add<SetWordTextChange>();
+        var types = config.ChangeTypes.ToArray();
+        types.Should().BeEquivalentTo([typeof(NewDefinitionChange), typeof(SetWordTextChange)]);
+    }
+}

--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -17,6 +17,7 @@ public class ChangeContext
 
     public Commit Commit { get; }
     public async ValueTask<ObjectSnapshot?> GetSnapshot(Guid entityId) => await _worker.GetSnapshot(entityId);
+    public IAsyncEnumerable<object> GetObjectsReferencing(Guid entityId) => _worker.GetSnapshotsReferencing(entityId).Select(s => s.Entity.DbObject);
     public async ValueTask<T?> GetCurrent<T>(Guid entityId) where T : class
     {
         var snapshot = await GetSnapshot(entityId);

--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -17,7 +17,10 @@ public class ChangeContext
 
     public Commit Commit { get; }
     public async ValueTask<ObjectSnapshot?> GetSnapshot(Guid entityId) => await _worker.GetSnapshot(entityId);
-    public IAsyncEnumerable<object> GetObjectsReferencing(Guid entityId) => _worker.GetSnapshotsReferencing(entityId).Select(s => s.Entity.DbObject);
+    public IAsyncEnumerable<object> GetObjectsReferencing(Guid entityId, bool includeDeleted = false)
+    {
+        return _worker.GetSnapshotsReferencing(entityId, includeDeleted).Select(s => s.Entity.DbObject);
+    }
     public async ValueTask<T?> GetCurrent<T>(Guid entityId) where T : class
     {
         var snapshot = await GetSnapshot(entityId);

--- a/src/SIL.Harmony/CrdtConfig.cs
+++ b/src/SIL.Harmony/CrdtConfig.cs
@@ -23,7 +23,9 @@ public class CrdtConfig
     /// </summary>
     public bool AlwaysValidateCommits { get; set; } = true;
     public ChangeTypeListBuilder ChangeTypeListBuilder { get; } = new();
+    public IEnumerable<Type> ChangeTypes => ChangeTypeListBuilder.Types.Select(t => t.DerivedType);
     public ObjectTypeListBuilder ObjectTypeListBuilder { get; } = new();
+    public IEnumerable<Type> ObjectTypes => ObjectTypeListBuilder.AdapterProviders.SelectMany(p => p.GetRegistrations().Select(r => r.ObjectDbType));
     public JsonSerializerOptions JsonSerializerOptions => _lazyJsonSerializerOptions.Value;
     private readonly Lazy<JsonSerializerOptions> _lazyJsonSerializerOptions;
 

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -125,7 +125,7 @@ internal class SnapshotWorker
                 {
                     intermediateSnapshots[prevSnapshot.Entity.Id] = prevSnapshot;
                 }
-                
+
                 await _crdtConfig.BeforeSaveObject.Invoke(entity.DbObject, newSnapshot);
 
                 AddSnapshot(newSnapshot);
@@ -200,6 +200,11 @@ internal class SnapshotWorker
         _snapshotLookup[entityId] = snapshot?.Id;
 
         return snapshot;
+    }
+
+    internal IAsyncEnumerable<ObjectSnapshot> GetSnapshotsReferencing(Guid entityId)
+    {
+        return _crdtRepository.CurrentSnapshots().Where(e => e.References.Contains(entityId)).AsAsyncEnumerable();
     }
 
     private void AddSnapshot(ObjectSnapshot snapshot)

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -202,9 +202,11 @@ internal class SnapshotWorker
         return snapshot;
     }
 
-    internal IAsyncEnumerable<ObjectSnapshot> GetSnapshotsReferencing(Guid entityId)
+    internal IAsyncEnumerable<ObjectSnapshot> GetSnapshotsReferencing(Guid entityId, bool includeDeleted = false)
     {
-        return _crdtRepository.CurrentSnapshots().Where(e => e.References.Contains(entityId)).AsAsyncEnumerable();
+        return _crdtRepository.CurrentSnapshots()
+            .Where(s => (includeDeleted || !s.EntityIsDeleted) && s.References.Contains(entityId))
+            .AsAsyncEnumerable();
     }
 
     private void AddSnapshot(ObjectSnapshot snapshot)


### PR DESCRIPTION
in order to prevent reference cycles we need to be able to determine what is referencing an object. We can use the same technique used in MarkDeleted to determine what's referencing an object and go from there