### PR TITLE
avoid race conditions when adding commits

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/src/SIL.Harmony.Sample/Models/Word.cs
+++ b/src/SIL.Harmony.Sample/Models/Word.cs
@@ -39,4 +39,10 @@ public class Word : IObjectBase<Word>
             DeletedAt = DeletedAt
         };
     }
+
+    public override string ToString()
+    {
+        return
+            $"{nameof(Text)}: {Text}, {nameof(Id)}: {Id}, {nameof(Note)}: {Note}, {nameof(DeletedAt)}: {DeletedAt}, {nameof(AntonymId)}: {AntonymId}, {nameof(ImageResourceId)}: {ImageResourceId}";
+    }
 }

--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
@@ -83,28 +83,12 @@
   },
   {
     $type: Commit,
-    Snapshots: [
-      {
-        $type: ObjectSnapshot,
-        Id: Guid_6,
-        TypeName: Word,
-        Entity: {
-          $type: Word,
-          Text: second,
-          Id: Guid_2
-        },
-        EntityId: Guid_2,
-        EntityIsDeleted: false,
-        CommitId: Guid_7,
-        IsRoot: false
-      }
-    ],
     Hash: Hash_3,
     ParentHash: Hash_2,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
-        CommitId: Guid_7,
+        CommitId: Guid_6,
         EntityId: Guid_2,
         Change: {
           $type: SetWordTextChange,
@@ -117,9 +101,9 @@
     CompareKey: {
       $type: ValueTuple<DateTimeOffset, long,
       Item1: DateTimeOffset_3,
-      Item3: Guid_7
+      Item3: Guid_6
     },
-    Id: Guid_7,
+    Id: Guid_6,
     HybridDateTime: {
       $type: HybridDateTime,
       DateTime: DateTimeOffset_3
@@ -135,7 +119,7 @@
     Snapshots: [
       {
         $type: ObjectSnapshot,
-        Id: Guid_8,
+        Id: Guid_7,
         TypeName: Word,
         Entity: {
           $type: Word,
@@ -145,7 +129,7 @@
         },
         EntityId: Guid_2,
         EntityIsDeleted: false,
-        CommitId: Guid_9,
+        CommitId: Guid_8,
         IsRoot: false
       }
     ],
@@ -154,7 +138,7 @@
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
-        CommitId: Guid_9,
+        CommitId: Guid_8,
         EntityId: Guid_2,
         Change: {
           $type: SetWordTextChange,
@@ -167,9 +151,9 @@
     CompareKey: {
       $type: ValueTuple<DateTimeOffset, long,
       Item1: DateTimeOffset_4,
-      Item3: Guid_9
+      Item3: Guid_8
     },
-    Id: Guid_9,
+    Id: Guid_8,
     HybridDateTime: {
       $type: HybridDateTime,
       DateTime: DateTimeOffset_4

--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
@@ -75,7 +75,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         await WriteNextChange(SetWord(Guid.NewGuid(), "change 1"));
         await WriteNextChange(SetWord(Guid.NewGuid(), "change 2"));
         DbContext.Snapshots.Should().HaveCount(2);
-        await Verify(DbContext.Commits);
+        await Verify(DbContext.Commits.DefaultOrder().Include(c => c.ChangeEntities).Include(c => c.Snapshots));
 
         await WriteNextChange(SetWord(Guid.NewGuid(), "change 3"));
         DbContext.Snapshots.Should().HaveCount(3);

--- a/src/SIL.Harmony.Tests/MultiThreadingTests.cs
+++ b/src/SIL.Harmony.Tests/MultiThreadingTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Data.Sqlite;
+using Xunit.Abstractions;
+
+namespace SIL.Harmony.Tests;
+
+public class MultiThreadingTests(ITestOutputHelper output)
+{
+    private const string _connectionString = "Data Source=file:MultiThreadingTests.db?mode=memory&cache=shared";
+    private static async Task<Exception?> Run(ITestOutputHelper output,
+        CancellationTokenSource cancellationTokenSource,
+        bool debug)
+    {
+        return await Task.Run(() =>
+        {
+            Exception? exception = null;
+            var t = new Thread(() =>
+            {
+                var random = new Random();
+                var fixture = new DataModelTestBase(new SqliteConnection(_connectionString));
+                fixture.InitializeAsync().Wait();
+                var id = Guid.NewGuid();
+                for (var i = 0; i < 100; i++)
+                {
+                    var value = "test" + i;
+                    try
+                    {
+                        Thread.Sleep(random.Next(1, 10));
+
+                        _ = fixture.WriteNextChange(fixture.SetWord(id, value)).Result;
+
+                        if (debug) output.WriteLine($"id: {id}, value:{value}");
+                        if (cancellationTokenSource.IsCancellationRequested) return;
+                    }
+                    catch (Exception e)
+                    {
+                        output.WriteLine($"id: {id}, value:{value}, error: {e}");
+                        cancellationTokenSource.Cancel();
+                        exception = e;
+                        return;
+                    }
+                }
+            });
+            t.Start();
+            t.Join();
+            return exception;
+        });
+    }
+
+    [Fact]
+    public async Task CanApplyChangesWithoutError()
+    {
+        //ensure the database is created before running the tests
+        _ = new DataModelTestBase(new SqliteConnection(_connectionString));
+        bool debug = false;
+        var cancellationTokenSource = new CancellationTokenSource();
+        var results = await Task.WhenAll(
+            Run(output, cancellationTokenSource, debug),
+            Run(output, cancellationTokenSource, debug),
+            Run(output, cancellationTokenSource, debug)
+        );
+        foreach (var exception in results)
+        {
+            exception.Should().BeNull();
+        }
+
+    }
+}

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -234,6 +234,13 @@ public class DataModel : ISyncable, IAsyncDisposable
         }
     }
 
+    public async Task RegenerateSnapshots()
+    {
+        await _crdtRepository.DeleteSnapshotsAndProjectedTables();
+        _crdtRepository.ClearChangeTracker();
+        var allCommits = await _crdtRepository.CurrentCommits().AsNoTracking().ToArrayAsync();
+        await UpdateSnapshots(allCommits.First(), allCommits);
+    }
 
     public async Task<ObjectSnapshot> GetLatestSnapshotByObjectId(Guid entityId)
     {

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -40,6 +40,11 @@ internal class CrdtRepository
         }
     }
 
+    internal void ClearChangeTracker()
+    {
+        _dbContext.ChangeTracker.Clear();
+    }
+
     private IQueryable<ObjectSnapshot> Snapshots => _dbContext.Snapshots.AsNoTracking();
 
     private IQueryable<Commit> Commits => _dbContext.Commits;
@@ -356,6 +361,7 @@ internal class ScopedDbContext(ICrdtDbContext inner, Commit ignoreChangesAfter) 
     }
 
     public DatabaseFacade Database => inner.Database;
+    public ChangeTracker ChangeTracker => inner.ChangeTracker;
 
     public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
     {

--- a/src/SIL.Harmony/Db/ICrdtDbContext.cs
+++ b/src/SIL.Harmony/Db/ICrdtDbContext.cs
@@ -12,6 +12,7 @@ public interface ICrdtDbContext
     ValueTask<object?> FindAsync(Type entityType, params object?[]? keyValues);
     DbSet<TEntity> Set<TEntity>() where TEntity : class;
     DatabaseFacade Database { get; }
+    ChangeTracker ChangeTracker { get; }
     EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
     EntityEntry Entry(object entity);
     EntityEntry Add(object entity);

--- a/src/SIL.Harmony/SIL.Harmony.csproj
+++ b/src/SIL.Harmony/SIL.Harmony.csproj
@@ -15,6 +15,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+      <PackageReference Include="Nito.AsyncEx.Coordination" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
if commits are added by 2 different connections, then snapshots can get lost due to the db context using cached commits in the change tracker