### PR TITLE
Include snapshots from current commit when finding referencing snapshots

### DIFF
--- a/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
+++ b/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
@@ -17,7 +17,7 @@ public class TagWordChange(WordTag wordTag) : CreateChange<WordTag>(wordTag.Id =
             Id = EntityId,
             WordId = WordId,
             TagId = TagId,
-            DeletedAt = isDuplicate ? DateTimeOffset.UtcNow : null
+            DeletedAt = isDuplicate ? commit.DateTime : null
         };
     }
 

--- a/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
+++ b/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
@@ -11,13 +11,15 @@ public class TagWordChange(WordTag wordTag) : CreateChange<WordTag>(wordTag.Id =
 
     public async override ValueTask<WordTag> NewEntity(Commit commit, IChangeContext context)
     {
-        var isDuplicate = await IsDuplicate(context);
+        bool delete = await IsDuplicate(context)
+            || await context.IsObjectDeleted(WordId)
+            || await context.IsObjectDeleted(TagId);
         return new WordTag()
         {
             Id = EntityId,
             WordId = WordId,
             TagId = TagId,
-            DeletedAt = isDuplicate ? commit.DateTime : null
+            DeletedAt = delete ? commit.DateTime : null
         };
     }
 

--- a/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
+++ b/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
@@ -1,0 +1,35 @@
+﻿using SIL.Harmony.Changes;
+using SIL.Harmony.Entities;
+using SIL.Harmony.Sample.Models;
+
+namespace SIL.Harmony.Sample.Changes;
+
+public class TagWordChange(WordTag wordTag) : CreateChange<WordTag>(wordTag.Id == Guid.Empty ? Guid.NewGuid() : wordTag.Id), ISelfNamedType<TagWordChange>
+{
+    public Guid WordId { get; } = wordTag.WordId;
+    public Guid TagId { get; } = wordTag.TagId;
+
+    public async override ValueTask<WordTag> NewEntity(Commit commit, IChangeContext context)
+    {
+        var isDuplicate = await IsDuplicate(context);
+        return new WordTag()
+        {
+            Id = EntityId,
+            WordId = WordId,
+            TagId = TagId,
+            DeletedAt = isDuplicate ? DateTimeOffset.UtcNow : null
+        };
+    }
+
+    private async Task<bool> IsDuplicate(IChangeContext context)
+    {
+        await foreach (var tag in context.GetObjectsReferencing(WordId).OfType<WordTag>())
+        {
+            if (tag.TagId == TagId)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
+++ b/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
@@ -48,13 +48,19 @@ public static class CrdtSampleKernel
                 .Add<SetOrderChange<Definition>>()
                 .Add<SetDefinitionPartOfSpeechChange>()
                 .Add<SetTagChange>()
+                .Add<TagWordChange>()
                 .Add<DeleteChange<Word>>()
                 .Add<DeleteChange<Definition>>()
                 .Add<DeleteChange<Example>>()
                 .Add<DeleteChange<Tag>>()
                 ;
             config.ObjectTypeListBuilder.DefaultAdapter()
-                .Add<Word>()
+                .Add<Word>(builder =>
+                {
+                    builder.HasMany(w => w.Tags)
+                        .WithMany()
+                        .UsingEntity<WordTag>();
+                })
                 .Add<Definition>(builder =>
                 {
                     builder.HasOne<Word>()
@@ -66,6 +72,11 @@ public static class CrdtSampleKernel
                 .Add<Tag>(builder =>
                 {
                     builder.HasIndex(tag => tag.Text).IsUnique();
+                })
+                .Add<WordTag>(builder =>
+                {
+                    builder.HasKey(wt => wt.Id);
+                    builder.HasIndex(wt => new { wt.WordId, wt.TagId }).IsUnique();
                 });
         });
         return services;

--- a/src/SIL.Harmony.Sample/Models/Word.cs
+++ b/src/SIL.Harmony.Sample/Models/Word.cs
@@ -37,13 +37,16 @@ public class Word : IObjectBase<Word>
             Text = Text,
             Note = Note,
             AntonymId = AntonymId,
-            DeletedAt = DeletedAt
+            DeletedAt = DeletedAt,
+            ImageResourceId = ImageResourceId,
+            Tags = Tags.Select(t => t.Copy()).Cast<Tag>().ToList(),
         };
     }
 
     public override string ToString()
     {
         return
-            $"{nameof(Text)}: {Text}, {nameof(Id)}: {Id}, {nameof(Note)}: {Note}, {nameof(DeletedAt)}: {DeletedAt}, {nameof(AntonymId)}: {AntonymId}, {nameof(ImageResourceId)}: {ImageResourceId}";
+            $"{nameof(Text)}: {Text}, {nameof(Id)}: {Id}, {nameof(Note)}: {Note}, {nameof(DeletedAt)}: {DeletedAt}, {nameof(AntonymId)}: {AntonymId}, {nameof(ImageResourceId)}: {ImageResourceId}" +
+            $", {nameof(Tags)}: {string.Join(", ", Tags.Select(t => t.Text))}";
     }
 }

--- a/src/SIL.Harmony.Sample/Models/Word.cs
+++ b/src/SIL.Harmony.Sample/Models/Word.cs
@@ -11,6 +11,7 @@ public class Word : IObjectBase<Word>
     public DateTimeOffset? DeletedAt { get; set; }
     public Guid? AntonymId { get; set; }
     public Guid? ImageResourceId { get; set; }
+    public List<Tag> Tags { get; set; } = new();
 
     public Guid[] GetReferences()
     {

--- a/src/SIL.Harmony.Sample/Models/WordTag.cs
+++ b/src/SIL.Harmony.Sample/Models/WordTag.cs
@@ -1,0 +1,35 @@
+using SIL.Harmony.Entities;
+
+namespace SIL.Harmony.Sample.Models;
+
+public class WordTag : IObjectBase<WordTag>
+{
+    public Guid Id { get; init; }
+    public required Guid WordId { get; init; }
+    public required Guid TagId { get; init; }
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public Guid[] GetReferences()
+    {
+        return [WordId, TagId];
+    }
+
+    public void RemoveReference(Guid id, CommitBase commit)
+    {
+        if (WordId == id || TagId == id)
+        {
+            DeletedAt = commit.DateTime;
+        }
+    }
+
+    public IObjectBase Copy()
+    {
+        return new WordTag
+        {
+            Id = Id,
+            WordId = WordId,
+            TagId = TagId,
+            DeletedAt = DeletedAt
+        };
+    }
+}

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -138,6 +138,11 @@ public class DataModelTestBase : IAsyncLifetime
         return new SetTagChange(entityId, value);
     }
 
+    public IChange TagWord(Guid wordId, Guid tagId)
+    {
+        return new TagWordChange(new WordTag { WordId = wordId, TagId = tagId });
+    }
+
     public IChange DeleteTag(Guid entityId)
     {
         return new DeleteChange<Tag>(entityId);

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -76,9 +76,9 @@ public class DataModelTestBase : IAsyncLifetime
         return await WriteChange(_localClientId, NextDate(), change, add);
     }
 
-    public async ValueTask<Commit> WriteNextChange(IEnumerable<IChange> changes)
+    public async ValueTask<Commit> WriteNextChange(IEnumerable<IChange> changes, bool add = true)
     {
-        return await WriteChange(_localClientId, NextDate(), changes);
+        return await WriteChange(_localClientId, NextDate(), changes, add);
     }
 
     public async ValueTask<Commit> WriteChangeAfter(Commit after, IChange change)

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -138,9 +138,9 @@ public class DataModelTestBase : IAsyncLifetime
         return new SetTagChange(entityId, value);
     }
 
-    public IChange TagWord(Guid wordId, Guid tagId)
+    public IChange TagWord(Guid wordId, Guid tagId, Guid entityId = default)
     {
-        return new TagWordChange(new WordTag { WordId = wordId, TagId = tagId });
+        return new TagWordChange(new WordTag { Id = entityId, WordId = wordId, TagId = tagId });
     }
 
     public IChange DeleteTag(Guid entityId)

--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -168,6 +168,8 @@
       DeletedAt (DateTimeOffset?)
       SnapshotId (no field, Guid?) Shadow FK Index
       Text (string) Required Index
+    Skip navigations: 
+      Word (no field, IEnumerable<Word>) CollectionWord Inverse: Tags
     Keys: 
       Id PK
     Foreign keys: 
@@ -192,6 +194,8 @@
       Note (string)
       SnapshotId (no field, Guid?) Shadow FK Index
       Text (string) Required
+    Skip navigations: 
+      Tags (List<Tag>) CollectionTag Inverse: Word
     Keys: 
       Id PK
     Foreign keys: 
@@ -204,6 +208,31 @@
       Relational:Schema: 
       Relational:SqlQuery: 
       Relational:TableName: Word
+      Relational:ViewName: 
+      Relational:ViewSchema: 
+  EntityType: WordTag
+    Properties: 
+      Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
+      DeletedAt (DateTimeOffset?)
+      SnapshotId (no field, Guid?) Shadow FK Index
+      TagId (Guid) Required FK Index
+      WordId (Guid) Required FK Index
+    Keys: 
+      Id PK
+    Foreign keys: 
+      WordTag {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
+      WordTag {'TagId'} -> Tag {'Id'} Required Cascade
+      WordTag {'WordId'} -> Word {'Id'} Required Cascade
+    Indexes: 
+      SnapshotId Unique
+      TagId
+      WordId, TagId Unique
+    Annotations: 
+      DiscriminatorProperty: 
+      Relational:FunctionName: 
+      Relational:Schema: 
+      Relational:SqlQuery: 
+      Relational:TableName: WordTag
       Relational:ViewName: 
       Relational:ViewSchema: 
 Annotations: 

--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -123,6 +123,11 @@ public class SnapshotTests : DataModelTestBase
                 TagWord(wordId, tagId),
                 TagWord(wordId, tagId),
             ]);
+
+        var word = await DataModel.QueryLatest<Word>().Include(w => w.Tags)
+            .Where(w => w.Id == wordId).FirstOrDefaultAsync();
+        word.Should().NotBeNull();
+        word.Tags.Should().BeEquivalentTo([new Tag { Id = tagId, Text = "tag-1" }]);
     }
 
     [Fact]

--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -65,8 +65,7 @@ public class SnapshotTests : DataModelTestBase
     public async Task OnlySaveTheLastSnapshotWhenThereAreMultipleChangesToAnEntityInOneCommit()
     {
         var entityId = Guid.NewGuid();
-        await WriteChange(_localClientId,
-            DateTimeOffset.Now,
+        await WriteNextChange(
             [
                 SetWord(entityId, "change1"),
                 SetWord(entityId, "change2"),
@@ -93,13 +92,8 @@ public class SnapshotTests : DataModelTestBase
     public async Task CanRecreateUniqueConstraintConflictingValueInOneCommit()
     {
         var entityId = Guid.NewGuid();
-        await WriteChange(_localClientId,
-            DateTimeOffset.Now,
-            [
-                SetTag(entityId, "tag-1"),
-            ]);
-        await WriteChange(_localClientId,
-            DateTimeOffset.Now,
+        await WriteNextChange(SetTag(entityId, "tag-1"));
+        await WriteNextChange(
             [
                 DeleteTag(entityId),
                 SetTag(Guid.NewGuid(), "tag-1"),
@@ -111,14 +105,12 @@ public class SnapshotTests : DataModelTestBase
     {
         var wordId = Guid.NewGuid();
         var tagId = Guid.NewGuid();
-        await WriteChange(_localClientId,
-            DateTimeOffset.Now,
+        await WriteNextChange(
             [
                 SetWord(wordId, "test root"),
                 SetTag(tagId, "tag-1"),
             ]);
-        await WriteChange(_localClientId,
-            DateTimeOffset.Now,
+        await WriteNextChange(
             [
                 TagWord(wordId, tagId),
                 TagWord(wordId, tagId),

--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -107,6 +107,25 @@ public class SnapshotTests : DataModelTestBase
     }
 
     [Fact]
+    public async Task DuplicatePreventionHandlesDuplicatesInSingleCommit()
+    {
+        var wordId = Guid.NewGuid();
+        var tagId = Guid.NewGuid();
+        await WriteChange(_localClientId,
+            DateTimeOffset.Now,
+            [
+                SetWord(wordId, "test root"),
+                SetTag(tagId, "tag-1"),
+            ]);
+        await WriteChange(_localClientId,
+            DateTimeOffset.Now,
+            [
+                TagWord(wordId, tagId),
+                TagWord(wordId, tagId),
+            ]);
+    }
+
+    [Fact]
     public async Task RegenerateSnapshots_WillArriveAtTheSameState()
     {
         var entityId = Guid.NewGuid();

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -139,14 +139,11 @@ internal class SnapshotWorker
     /// <param name="commit"></param>
     private async ValueTask MarkDeleted(Guid deletedEntityId, Commit commit)
     {
-        var toRemoveRefFromIds = await GetSnapshotsReferencing(deletedEntityId, true)
-            .Select(s => s.EntityId)
+        var toRemoveRefFrom = await GetSnapshotsReferencing(deletedEntityId, true)
             .ToArrayAsync();
 
-        foreach (var entityId in toRemoveRefFromIds)
+        foreach (var snapshot in toRemoveRefFrom)
         {
-            var snapshot = await GetSnapshot(entityId); // AsTracking
-            if (snapshot is null) throw new NullReferenceException("unable to find snapshot for entity " + entityId);
             var hasBeenApplied = snapshot.CommitId == commit.Id;
             var updatedEntry = snapshot.Entity.Copy();
             var wasDeleted = updatedEntry.DeletedAt.HasValue;

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -139,6 +139,8 @@ internal class SnapshotWorker
     /// <param name="commit"></param>
     private async ValueTask MarkDeleted(Guid deletedEntityId, Commit commit)
     {
+        // Including deleted shouldn't be necessary, because change objects are responsible for not adding references to deleted entities.
+        // But maybe it's a good fallback.
         var toRemoveRefFrom = await GetSnapshotsReferencing(deletedEntityId, true)
             .ToArrayAsync();
 


### PR DESCRIPTION
`IChangeContext.GetObjectsReferencing()` makes it possible to e.g. delete duplicates in the context of a change to prevent db constraint violations. However, `GetObjectsReferencing()` currently does not consider snapshots generated in the current commit. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced tagging system that lets users associate words with multiple tags for improved organization.
- **Bug Fixes / Enhancements**
  - Implemented duplicate prevention to ensure each word tag is unique, enhancing data consistency.
  - Refined error handling during data operations for smoother and more reliable performance.
- **Refactor**
  - Streamlined the snapshot processing mechanism to better manage deletions and maintain system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->