### PR TITLE
Remove reference changes are lost

### DIFF
--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -2,7 +2,7 @@ using SIL.Harmony.Db;
 
 namespace SIL.Harmony.Changes;
 
-public class ChangeContext : IChangeContext
+internal class ChangeContext : IChangeContext
 {
     private readonly SnapshotWorker _worker;
     private readonly CrdtConfig _crdtConfig;

--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -1,3 +1,5 @@
+using SIL.Harmony.Db;
+
 namespace SIL.Harmony.Changes;
 
 public class ChangeContext : IChangeContext
@@ -5,14 +7,19 @@ public class ChangeContext : IChangeContext
     private readonly SnapshotWorker _worker;
     private readonly CrdtConfig _crdtConfig;
 
-    internal ChangeContext(Commit commit, SnapshotWorker worker, CrdtConfig crdtConfig)
+    internal ChangeContext(Commit commit, int commitIndex, IDictionary<Guid, ObjectSnapshot> intermediateSnapshots, SnapshotWorker worker, CrdtConfig crdtConfig)
     {
         _worker = worker;
         _crdtConfig = crdtConfig;
         Commit = commit;
+        CommitIndex = commitIndex;
+        IntermediateSnapshots = intermediateSnapshots;
     }
 
-    public CommitBase Commit { get; }
+    CommitBase IChangeContext.Commit => Commit;
+    public Commit Commit { get; }
+    public int CommitIndex { get; }
+    public IDictionary<Guid, ObjectSnapshot> IntermediateSnapshots { get; }
     public async ValueTask<IObjectSnapshot?> GetSnapshot(Guid entityId) => await _worker.GetSnapshot(entityId);
     public IAsyncEnumerable<object> GetObjectsReferencing(Guid entityId, bool includeDeleted = false)
     {


### PR DESCRIPTION
Resolves #30

Instead of dropping snapshots, this PR refactors the SnapshotWorker so that new snapshots triggered by deletes are handled by the same code that handles "normal" snapshots triggered by changes.

In theory we could take it even farther with something like:
`private async Task UpdateEntity(Id, Action<Entity, ChangeContext, ...> updater)` which would find the current entity, let the caller do there thing and then generate a new snapshot afterwards, checking whether it was deleted etc.

But, it's not quite that simple, so I didn't go for it in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage to validate robust handling of simultaneous updates and deletions, ensuring improved data integrity.
  
- **Refactor**
  - Streamlined internal change tracking and snapshot generation processes, enhancing overall system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->