### PR TITLE
Fix IsNew logic

### DIFF
--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
@@ -50,12 +50,29 @@
   },
   {
     $type: Commit,
+    Snapshots: [
+      {
+        $type: ObjectSnapshot,
+        Id: Guid_5,
+        TypeName: Word,
+        Entity: {
+          $type: Word,
+          Text: first,
+          Note: a word note,
+          Id: Guid_2
+        },
+        EntityId: Guid_2,
+        EntityIsDeleted: false,
+        CommitId: Guid_6,
+        IsRoot: false
+      }
+    ],
     Hash: Hash_2,
     ParentHash: Hash_1,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
-        CommitId: Guid_5,
+        CommitId: Guid_6,
         EntityId: Guid_2,
         Change: {
           $type: SetWordNoteChange,
@@ -68,9 +85,9 @@
     CompareKey: {
       $type: ValueTuple<DateTimeOffset, long,
       Item1: DateTimeOffset_2,
-      Item3: Guid_5
+      Item3: Guid_6
     },
-    Id: Guid_5,
+    Id: Guid_6,
     HybridDateTime: {
       $type: HybridDateTime,
       DateTime: DateTimeOffset_2
@@ -88,7 +105,7 @@
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
-        CommitId: Guid_6,
+        CommitId: Guid_7,
         EntityId: Guid_2,
         Change: {
           $type: SetWordTextChange,
@@ -101,9 +118,9 @@
     CompareKey: {
       $type: ValueTuple<DateTimeOffset, long,
       Item1: DateTimeOffset_3,
-      Item3: Guid_6
+      Item3: Guid_7
     },
-    Id: Guid_6,
+    Id: Guid_7,
     HybridDateTime: {
       $type: HybridDateTime,
       DateTime: DateTimeOffset_3
@@ -119,7 +136,7 @@
     Snapshots: [
       {
         $type: ObjectSnapshot,
-        Id: Guid_7,
+        Id: Guid_8,
         TypeName: Word,
         Entity: {
           $type: Word,
@@ -129,7 +146,7 @@
         },
         EntityId: Guid_2,
         EntityIsDeleted: false,
-        CommitId: Guid_8,
+        CommitId: Guid_9,
         IsRoot: false
       }
     ],
@@ -138,7 +155,7 @@
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
-        CommitId: Guid_8,
+        CommitId: Guid_9,
         EntityId: Guid_2,
         Change: {
           $type: SetWordTextChange,
@@ -151,9 +168,9 @@
     CompareKey: {
       $type: ValueTuple<DateTimeOffset, long,
       Item1: DateTimeOffset_4,
-      Item3: Guid_8
+      Item3: Guid_9
     },
-    Id: Guid_8,
+    Id: Guid_9,
     HybridDateTime: {
       $type: HybridDateTime,
       DateTime: DateTimeOffset_4

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -242,13 +242,13 @@ internal class SnapshotWorker
     private bool IsNew(ObjectSnapshot snapshot)
     {
         var entityId = snapshot.EntityId;
-        if (_rootSnapshots.TryGetValue(entityId, out var rootSnapshot))
-        {
-            return rootSnapshot.Id != snapshot.Id;
-        }
         if (_pendingSnapshots.TryGetValue(entityId, out var pendingSnapshot))
         {
-            return pendingSnapshot.Id != snapshot.Id;
+            return pendingSnapshot.Id == snapshot.Id;
+        }
+        if (_rootSnapshots.TryGetValue(entityId, out var rootSnapshot))
+        {
+            return rootSnapshot.Id == snapshot.Id;
         }
         return false;
     }


### PR DESCRIPTION
I started working on [deferring intermediate snapshot selection](https://github.com/sillsdev/harmony/pull/31#discussion_r2009994806) and ran into this bug. Somehow we both 😱 overlooked that the boolean logic was backwards **and** that it's important to check pending before root.

I expect to delete the `IsNew` check entirely, but this PR also corrects the snapshot data of a test, so I'd like to merge it first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced tracking by capturing detailed snapshots during content updates, enriching the historical record for revisions.

- **Refactor**
  - Restructured internal identifiers to improve consistency.
  - Revised the logic for determining update status, ensuring a more reliable and accurate change history for a better review experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->