### PR TITLE
allow setting commit id on init, required for some insert expressions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.15" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />

--- a/src/SIL.Harmony.Core/CommitBase.cs
+++ b/src/SIL.Harmony.Core/CommitBase.cs
@@ -23,7 +23,7 @@ public abstract class CommitBase
     }
 
     public (DateTimeOffset, long, Guid) CompareKey => (HybridDateTime.DateTime, HybridDateTime.Counter, Id);
-    public Guid Id { get; }
+    public Guid Id { get; init; }
     public required HybridDateTime HybridDateTime { get; init; }
     public DateTimeOffset DateTime => HybridDateTime.DateTime;
     public CommitMetadata Metadata { get; init; } = new();

--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -236,4 +236,4 @@
       Relational:ViewName: 
       Relational:ViewSchema: 
 Annotations: 
-  ProductVersion: 8.0.11
+  ProductVersion: 8.0.15


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced object initialization by allowing key identifier values to be set during creation.
  - Added an optional parameter to improve flexibility in querying related change entities.

- **Chores**
  - Updated package dependencies for Entity Framework Core to the latest version.
  - Updated model verification annotation to reflect the new version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->