### PR TITLE
allow manually flushing deferred commits, add index to entity Id on snapshot table

### DIFF
--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -72,6 +72,7 @@
     Foreign keys: 
       ObjectSnapshot {'CommitId'} -> Commit {'Id'} Required Cascade ToDependent: Snapshots ToPrincipal: Commit
     Indexes: 
+      EntityId
       CommitId, EntityId Unique
     Annotations: 
       DiscriminatorProperty: 

--- a/src/SIL.Harmony/Db/EntityConfig/SnapshotEntityConfig.cs
+++ b/src/SIL.Harmony/Db/EntityConfig/SnapshotEntityConfig.cs
@@ -12,6 +12,7 @@ public class SnapshotEntityConfig(JsonSerializerOptions jsonSerializerOptions) :
         builder.ToTable("Snapshots");
         builder.HasKey(s => s.Id);
         builder.HasIndex(s => new { s.CommitId, s.EntityId }).IsUnique();
+        builder.HasIndex(s => s.EntityId);
         builder
             .HasOne(s => s.Commit)
             .WithMany(c => c.Snapshots)


### PR DESCRIPTION
the index was deemed to improve performance when importing a large amount of data.

Being able to defer commits is very useful when importing a large amount of data, however the caller needs to be able to explicitly flush the changes as they don't usually know when they are adding the last change which was required in the previous design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new database index on the EntityId column to improve query performance for snapshots.

- **Refactor**
  - Renamed and made public a method for processing deferred commits, now accessible as FlushDeferredCommits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->