### PR TITLE
enable using a compiled model

### DIFF
--- a/src/SIL.Harmony/Db/EntityConfig/ChangeEntityConfig.cs
+++ b/src/SIL.Harmony/Db/EntityConfig/ChangeEntityConfig.cs
@@ -6,23 +6,45 @@ using SIL.Harmony.Changes;
 
 namespace SIL.Harmony.Db.EntityConfig;
 
-public class ChangeEntityConfig(JsonSerializerOptions jsonSerializerOptions) : IEntityTypeConfiguration<ChangeEntity<IChange>>
+public class ChangeEntityConfig(JsonSerializerOptions jsonSerializerOptions)
+    : IEntityTypeConfiguration<ChangeEntity<IChange>>
 {
+    public ChangeEntityConfig() : this(JsonSerializerOptions.Default)
+    {
+    }
+
     public void Configure(EntityTypeBuilder<ChangeEntity<IChange>> builder)
     {
         builder.ToTable("ChangeEntities");
         builder.HasKey(c => new { c.CommitId, c.Index });
-        builder.Property(c => c.Change)
-            .HasColumnType("jsonb")
-            .HasConversion(
-                change => JsonSerializer.Serialize(change, jsonSerializerOptions),
-                json => DeserializeChange(json)
-            );
+        var changeProperty = builder.Property(c => c.Change)
+            .HasColumnType("jsonb");
+        if (EF.IsDesignTime)
+        {
+            changeProperty
+                .HasConversion(
+                    change => SerializeChange(change, null),
+                    json => DeserializeChange(json, null)
+                );
+        }
+        else
+        {
+            changeProperty
+                .HasConversion(
+                    change => SerializeChange(change, jsonSerializerOptions),
+                    json => DeserializeChange(json, jsonSerializerOptions)
+                );
+        }
     }
 
-    private IChange DeserializeChange(string json)
+    public static IChange DeserializeChange(string json, JsonSerializerOptions? jsonSerializerOptions)
     {
         return JsonSerializer.Deserialize<IChange>(json, jsonSerializerOptions) ??
                throw new SerializationException("Could not deserialize Change: " + json);
+    }
+
+    public static string SerializeChange(IChange change, JsonSerializerOptions? jsonSerializerOptions)
+    {
+        return JsonSerializer.Serialize(change, jsonSerializerOptions);
     }
 }

--- a/src/SIL.Harmony/Db/EntityConfig/CommitEntityConfig.cs
+++ b/src/SIL.Harmony/Db/EntityConfig/CommitEntityConfig.cs
@@ -1,6 +1,8 @@
+using System.Runtime.Serialization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SIL.Harmony.Changes;
 
 namespace SIL.Harmony.Db.EntityConfig;
 
@@ -24,11 +26,22 @@ public class CommitEntityConfig : IEntityTypeConfiguration<Commit>
         builder.Property(c => c.Metadata)
             .HasColumnType("jsonb")
             .HasConversion(
-                m => JsonSerializer.Serialize(m, (JsonSerializerOptions?)null),
-                json => JsonSerializer.Deserialize<CommitMetadata>(json, (JsonSerializerOptions?)null) ?? new()
+                m => Serialize(m, null),
+                json => Deserialize(json, null) ?? new()
             );
         builder.HasMany(c => c.ChangeEntities)
             .WithOne()
             .HasForeignKey(c => c.CommitId);
+    }
+
+    public static CommitMetadata Deserialize(string json, JsonSerializerOptions? jsonSerializerOptions)
+    {
+        return JsonSerializer.Deserialize<CommitMetadata>(json, jsonSerializerOptions) ??
+               throw new SerializationException("Could not deserialize CommitMetadata: " + json);
+    }
+
+    public static string Serialize(CommitMetadata commitMetadata, JsonSerializerOptions? jsonSerializerOptions)
+    {
+        return JsonSerializer.Serialize(commitMetadata, jsonSerializerOptions);
     }
 }


### PR DESCRIPTION
compiled models require static access to all converters. In order for this to work it requires some customization of the compiled model, but this does seem to be a valid workaround for issues using a compiled model.