### PR TITLE
fix constraint violation on sync

### DIFF
--- a/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
+++ b/src/SIL.Harmony.Sample/Changes/TagWordChange.cs
@@ -1,13 +1,27 @@
-﻿using SIL.Harmony.Changes;
+﻿using System.Text.Json.Serialization;
+using SIL.Harmony.Changes;
 using SIL.Harmony.Entities;
 using SIL.Harmony.Sample.Models;
 
 namespace SIL.Harmony.Sample.Changes;
 
-public class TagWordChange(WordTag wordTag) : CreateChange<WordTag>(wordTag.Id == Guid.Empty ? Guid.NewGuid() : wordTag.Id), ISelfNamedType<TagWordChange>
+public class TagWordChange : CreateChange<WordTag>, ISelfNamedType<TagWordChange>
 {
-    public Guid WordId { get; } = wordTag.WordId;
-    public Guid TagId { get; } = wordTag.TagId;
+    public TagWordChange(WordTag wordTag) : base(wordTag.Id == Guid.Empty ? Guid.NewGuid() : wordTag.Id)
+    {
+        WordId = wordTag.WordId;
+        TagId = wordTag.TagId;
+    }
+
+    [JsonConstructor]
+    protected TagWordChange(Guid entityId, Guid wordId, Guid tagId) : base(entityId)
+    {
+        WordId = wordId;
+        TagId = tagId;
+    }
+
+    public Guid WordId { get; }
+    public Guid TagId { get; }
 
     public async override ValueTask<WordTag> NewEntity(Commit commit, IChangeContext context)
     {


### PR DESCRIPTION
related to https://github.com/sillsdev/languageforge-lexbox/issues/1615

WordTags are linking objects between a word and a tag. There is a constraint that there can only be one row with the same tag and word id. If a sync comes in that creates a word tag which already exists, but the commit precedes the local word tag we run into this constraint violation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved duplicate prevention to ensure that duplicate tag relationships are not created, even if a duplicate entry is inserted with an earlier version.

- **Tests**
  - Added a new test to verify that the system prevents duplicate tag relationships when a duplicate is created before the current version.

- **Refactor**
  - Updated internal class structures and constructors for better maintainability and serialization support.
  - Enhanced snapshot processing logic to handle deleted entities more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->