### PR TITLE
Allow getting objects of type via IChangeContext

### DIFF
--- a/src/SIL.Harmony.Core/IChangeContext.cs
+++ b/src/SIL.Harmony.Core/IChangeContext.cs
@@ -14,4 +14,5 @@ public interface IChangeContext
     public async ValueTask<bool> IsObjectDeleted(Guid entityId) => (await GetSnapshot(entityId))?.EntityIsDeleted ?? true;
     internal IObjectBase Adapt(object obj);
     IAsyncEnumerable<object> GetObjectsReferencing(Guid entityId, bool includeDeleted = false);
+    IAsyncEnumerable<T> GetObjectsOfType<T>(string jsonTypeName, bool includeDeleted = false) where T : class;
 }

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -158,6 +158,7 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteChangeBefore(commitA, SetTag(Guid.NewGuid(), tagText));
+        DataModel.QueryLatest<Tag>().Where(t => t.Text == tagText).Should().ContainSingle();
     }
 
     [Fact]
@@ -169,5 +170,6 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteNextChange(SetTag(renameTagId, tagText));
+        DataModel.QueryLatest<Tag>().Where(t => t.Text == tagText).Should().ContainSingle();
     }
 }

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -150,4 +150,24 @@ public class DataModelReferenceTests : DataModelTestBase
         def.Should().NotBeNull();
         def.DeletedAt.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task CanCreate2TagsWithTheSameNameOutOfOrder()
+    {
+        var tagText = "tag1";
+        var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
+        //represents someone syncing in a tag with the same name
+        await WriteChangeBefore(commitA, SetTag(Guid.NewGuid(), tagText));
+    }
+
+    [Fact]
+    public async Task CanUpdateTagWithTheSameNameOutOfOrder()
+    {
+        var tagText = "tag1";
+        var renameTagId = Guid.NewGuid();
+        await WriteNextChange(SetTag(renameTagId, "tag2"));
+        var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
+        //represents someone syncing in a tag with the same name
+        await WriteNextChange(SetTag(renameTagId, tagText));
+    }
 }

--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -25,5 +25,13 @@ internal class ChangeContext : IChangeContext
     {
         return _worker.GetSnapshotsReferencing(entityId, includeDeleted).Select(s => s.Entity.DbObject);
     }
+
+    public IAsyncEnumerable<T> GetObjectsOfType<T>(string jsonTypeName, bool includeDeleted = false) where T : class
+    {
+        return _worker.GetSnapshotsWhere(s => (includeDeleted || !s.EntityIsDeleted) && s.TypeName == jsonTypeName)
+            .Select(s => s.Entity.DbObject)
+            .OfType<T>();
+    }
+
     IObjectBase IChangeContext.Adapt(object obj) => _crdtConfig.ObjectTypeListBuilder.Adapt(obj);
 }


### PR DESCRIPTION
this enables changes to better enforce constraints when running to avoid conflicts with unique constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to retrieve objects by type and name, with optional inclusion of deleted items.
- **Bug Fixes**
	- Improved handling of tags with duplicate names, ensuring correct behavior when creating or updating tags with identical names, even in non-sequential commit orders.
- **Tests**
	- Added new tests to verify correct handling of tags with the same name in out-of-order commit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->