### PR TITLE
migrate to using db context factories

### DIFF
--- a/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
+++ b/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
@@ -194,6 +194,6 @@ public class CustomObjectAdapterTests
         myClass2.MyNumber.Should().Be(123.45m);
         myClass2.DeletedTime.Should().BeNull();
 
-        dataModel.QueryLatest<MyClass>().Should().NotBeEmpty();
+        dataModel.QueryLatest<MyClass>().ToBlockingEnumerable().Should().NotBeEmpty();
     }
 }

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -158,7 +158,7 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteChangeBefore(commitA, SetTag(Guid.NewGuid(), tagText));
-        DataModel.QueryLatest<Tag>().Where(t => t.Text == tagText).Should().ContainSingle();
+        DataModel.QueryLatest<Tag>().ToBlockingEnumerable().Where(t => t.Text == tagText).Should().ContainSingle();
     }
 
     [Fact]
@@ -170,6 +170,6 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteNextChange(SetTag(renameTagId, tagText));
-        DataModel.QueryLatest<Tag>().Where(t => t.Text == tagText).Should().ContainSingle();
+        DataModel.QueryLatest<Tag>().ToBlockingEnumerable().Where(t => t.Text == tagText).Should().ContainSingle();
     }
 }

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -2,9 +2,8 @@
 using SIL.Harmony.Changes;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
-using SIL.Harmony.Tests;
 
-namespace Tests;
+namespace SIL.Harmony.Tests;
 
 public class DataModelReferenceTests : DataModelTestBase
 {

--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
@@ -79,7 +79,7 @@ public class DataModelSimpleChanges : DataModelTestBase
 
         await WriteNextChange(SetWord(Guid.NewGuid(), "change 3"));
         DbContext.Snapshots.Should().HaveCount(3);
-        DataModel.QueryLatest<Word>().Should().HaveCount(3);
+        DataModel.QueryLatest<Word>().ToBlockingEnumerable().Should().HaveCount(3);
     }
 
     [Fact]

--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
@@ -1,12 +1,10 @@
-using SIL.Harmony;
 using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
-using SIL.Harmony.Tests;
 using Microsoft.EntityFrameworkCore;
 
-namespace Tests;
+namespace SIL.Harmony.Tests;
 
 public class DataModelSimpleChanges : DataModelTestBase
 {

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -18,7 +18,6 @@ public class DataModelTestBase : IAsyncLifetime
     private readonly bool _performanceTest;
     public readonly DataModel DataModel;
     public readonly SampleDbContext DbContext;
-    internal readonly CrdtRepository CrdtRepository;
     protected readonly MockTimeProvider MockTimeProvider = new();
 
     public DataModelTestBase(bool saveToDisk = false, bool alwaysValidate = true,
@@ -47,7 +46,6 @@ public class DataModelTestBase : IAsyncLifetime
         DbContext.Database.OpenConnection();
         DbContext.Database.EnsureCreated();
         DataModel = _services.GetRequiredService<DataModel>();
-        CrdtRepository = _services.GetRequiredService<CrdtRepository>();
     }
     
     public DataModelTestBase ForkDatabase(bool alwaysValidate = true)
@@ -170,6 +168,7 @@ public class DataModelTestBase : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
+
         await _services.DisposeAsync();
     }
 

--- a/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
+++ b/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
@@ -76,7 +76,7 @@ public class PersistExtraDataTests
     {
         var entityId = Guid.NewGuid();
         var commit = await _dataModelTestBase.WriteNextChange(new CreateExtraDataModelChange(entityId));
-        var extraDataModel = _dataModelTestBase.DataModel.QueryLatest<ExtraDataModel>().Should().ContainSingle().Subject;
+        var extraDataModel = _dataModelTestBase.DataModel.QueryLatest<ExtraDataModel>().ToBlockingEnumerable().Should().ContainSingle().Subject;
         extraDataModel.Id.Should().Be(entityId);
         extraDataModel.CommitId.Should().Be(commit.Id);
         extraDataModel.DateTime.Should().Be(commit.HybridDateTime.DateTime);

--- a/src/SIL.Harmony.Tests/RepositoryTests.cs
+++ b/src/SIL.Harmony.Tests/RepositoryTests.cs
@@ -21,7 +21,7 @@ public class RepositoryTests : IAsyncLifetime
             .AddCrdtDataSample(":memory:")
             .BuildServiceProvider();
 
-        _repository = _services.GetRequiredService<CrdtRepository>();
+        _repository = _services.GetRequiredService<CrdtRepositoryFactory>().CreateRepositorySync();
         _crdtDbContext = _services.GetRequiredService<SampleDbContext>();
     }
 

--- a/src/SIL.Harmony.Tests/RepositoryTests.cs
+++ b/src/SIL.Harmony.Tests/RepositoryTests.cs
@@ -34,6 +34,7 @@ public class RepositoryTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
+        await _repository.DisposeAsync();
         await _services.DisposeAsync();
     }
 

--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -116,8 +116,8 @@ public class SnapshotTests : DataModelTestBase
                 TagWord(wordId, tagId),
             ]);
 
-        var word = await DataModel.QueryLatest<Word>().Include(w => w.Tags)
-            .Where(w => w.Id == wordId).FirstOrDefaultAsync();
+        var word = await DataModel.QueryLatest<Word>(q => q.Include(w => w.Tags)
+            .Where(w => w.Id == wordId)).FirstOrDefaultAsync();
         word.Should().NotBeNull();
         word.Tags.Should().BeEquivalentTo([new Tag { Id = tagId, Text = "tag-1" }]);
     }
@@ -135,8 +135,8 @@ public class SnapshotTests : DataModelTestBase
         var tagCreation = await WriteNextChange(TagWord(wordId, tagId));
         await WriteChangeBefore(tagCreation, TagWord(wordId, tagId));
 
-        var word = await DataModel.QueryLatest<Word>().Include(w => w.Tags)
-            .Where(w => w.Id == wordId).FirstOrDefaultAsync();
+        var word = await DataModel.QueryLatest<Word>(q=> q.Include(w => w.Tags)
+            .Where(w => w.Id == wordId)).FirstOrDefaultAsync();
         word.Should().NotBeNull();
         word.Tags.Should().BeEquivalentTo([new Tag { Id = tagId, Text = "tag-1" }]);
     }

--- a/src/SIL.Harmony.Tests/SyncTests.cs
+++ b/src/SIL.Harmony.Tests/SyncTests.cs
@@ -116,7 +116,7 @@ public class SyncTests : IAsyncLifetime
 
         await _client2.DataModel.SyncWith(_client1.DataModel);
 
-        _client2.DataModel.QueryLatest<Definition>().Should()
-            .BeEquivalentTo(_client1.DataModel.QueryLatest<Definition>());
+        _client2.DataModel.QueryLatest<Definition>().ToBlockingEnumerable().Should()
+            .BeEquivalentTo(_client1.DataModel.QueryLatest<Definition>().ToBlockingEnumerable());
     }
 }

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -8,21 +9,34 @@ namespace SIL.Harmony;
 
 public static class CrdtKernel
 {
+    public static IServiceCollection AddCrdtDataDbFactory<TContext>(this IServiceCollection services,
+        Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
+    {
+
+        services.AddCrdtDataCore(configureCrdt);
+        services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactory<TContext>>();
+        return services;
+    }
+
     public static IServiceCollection AddCrdtData<TContext>(this IServiceCollection services,
-        Action<CrdtConfig> configureCrdt) where TContext: ICrdtDbContext
+        Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
+    {
+        services.AddCrdtDataCore(configureCrdt);
+        services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactoryNoContextFactory<TContext>>();
+        return services;
+    }
+    public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<CrdtConfig> configureCrdt)
     {
         services.AddLogging();
-        services.AddOptions<CrdtConfig>().Configure(configureCrdt).PostConfigure(crdtConfig => crdtConfig.ObjectTypeListBuilder.Freeze());
+        services.AddOptions<CrdtConfig>().Configure(configureCrdt)
+            .PostConfigure(crdtConfig => crdtConfig.ObjectTypeListBuilder.Freeze());
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<CrdtConfig>>().Value.JsonSerializerOptions);
         services.AddSingleton(TimeProvider.System);
         services.AddScoped<IHybridDateTimeProvider>(NewTimeProvider);
-        //must use factory, otherwise one context will be created for this registration, and one for the application.
-        //we want to have one context per application
-        services.AddScoped<ICrdtDbContext>(p => p.GetRequiredService<TContext>());
-        services.AddScoped<CrdtRepository>();
+        services.AddScoped<CrdtRepositoryFactory>();
         //must use factory method because DataModel constructor is internal
         services.AddScoped<DataModel>(provider => new DataModel(
-            provider.GetRequiredService<CrdtRepository>(),
+            provider.GetRequiredService<CrdtRepositoryFactory>(),
             provider.GetRequiredService<JsonSerializerOptions>(),
             provider.GetRequiredService<IHybridDateTimeProvider>(),
             provider.GetRequiredService<IOptions<CrdtConfig>>(),
@@ -43,8 +57,11 @@ public static class CrdtKernel
         //todo, if this causes issues getting the order correct, we can update the last date time after the db is created
         //as long as it's before we get a date time from the provider
         //todo use IMemoryCache to store the last date time, possibly based on the current project
-        var hybridDateTime = serviceProvider.GetRequiredService<CrdtRepository>().GetLatestDateTime();
+        using var repo = serviceProvider.GetRequiredService<CrdtRepositoryFactory>().CreateRepositorySync();
+        var hybridDateTime = repo.GetLatestDateTime();
         hybridDateTime ??= HybridDateTimeProvider.DefaultLastDateTime;
         return ActivatorUtilities.CreateInstance<HybridDateTimeProvider>(serviceProvider, hybridDateTime);
     }
 }
+
+

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -44,7 +44,7 @@ public static class CrdtKernel
         ));
         //must use factory method because ResourceService constructor is internal
         services.AddScoped<ResourceService>(provider => new ResourceService(
-            provider.GetRequiredService<CrdtRepository>(),
+            provider.GetRequiredService<CrdtRepositoryFactory>(),
             provider.GetRequiredService<IOptions<CrdtConfig>>(),
             provider.GetRequiredService<DataModel>(),
             provider.GetRequiredService<ILogger<ResourceService>>()

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -22,7 +22,7 @@ public static class CrdtKernel
         Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
         services.AddCrdtDataCore(configureCrdt);
-        services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactoryNoContextFactory<TContext>>();
+        services.AddScoped<ICrdtDbContextFactory, CrdtDbContextNoDisposeFactory<TContext>>();
         return services;
     }
     public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<CrdtConfig> configureCrdt)

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -146,6 +146,7 @@ public class DataModel : ISyncable, IAsyncDisposable
         {
             await using var repo = await _crdtRepositoryFactory.CreateRepository();
             using var locked = await repo.Lock();
+            repo.ClearChangeTracker();
             _timeProvider.TakeLatestTime(commits.Select(c => c.HybridDateTime));
             var (oldestChange, newCommits) = await repo.FilterExistingCommits(commits.ToArray());
             //no changes added
@@ -236,6 +237,7 @@ public class DataModel : ISyncable, IAsyncDisposable
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.DeleteSnapshotsAndProjectedTables();
+        repo.ClearChangeTracker();
         var allCommits = await repo.CurrentCommits().AsNoTracking().ToArrayAsync();
         await UpdateSnapshots(repo, allCommits.First(), allCommits);
     }

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -78,6 +78,7 @@ public class DataModel : ISyncable, IAsyncDisposable
             .ToArray();
         if (commits is []) return;
         using var locked = await repo.Lock();
+        repo.ClearChangeTracker();
 
         await using var transaction = await repo.BeginTransactionAsync();
         await repo.AddCommits(commits);
@@ -115,6 +116,7 @@ public class DataModel : ISyncable, IAsyncDisposable
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         if (await repo.HasCommit(commit.Id)) return;
         using var locked = await repo.Lock();
+        repo.ClearChangeTracker();
 
         await using var transaction = repo.IsInTransaction ? null : await repo.BeginTransactionAsync();
         await repo.AddCommit(commit);

--- a/src/SIL.Harmony/Db/CrdtDbContextFactory.cs
+++ b/src/SIL.Harmony/Db/CrdtDbContextFactory.cs
@@ -24,7 +24,7 @@ public interface ICrdtDbContextFactory
     ICrdtDbContext CreateDbContext();
 }
 
-public class CrdtDbContextFactoryNoContextFactory<TContext>(TContext dbContext) : ICrdtDbContextFactory
+public class CrdtDbContextNoDisposeFactory<TContext>(TContext dbContext) : ICrdtDbContextFactory
     where TContext : ICrdtDbContext
 {
     public Task<ICrdtDbContext> CreateDbContextAsync(CancellationToken cancellationToken = new CancellationToken())

--- a/src/SIL.Harmony/Db/CrdtDbContextFactory.cs
+++ b/src/SIL.Harmony/Db/CrdtDbContextFactory.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace SIL.Harmony.Db;
+
+public class CrdtDbContextFactory<TContext>(IDbContextFactory<TContext> dbContextFactory) : ICrdtDbContextFactory
+    where TContext : DbContext, ICrdtDbContext
+{
+    public async Task<ICrdtDbContext> CreateDbContextAsync(CancellationToken cancellationToken = new CancellationToken())
+    {
+        return await dbContextFactory.CreateDbContextAsync(cancellationToken);
+    }
+
+    public ICrdtDbContext CreateDbContext()
+    {
+        return dbContextFactory.CreateDbContext();
+    }
+}
+
+public interface ICrdtDbContextFactory
+{
+    Task<ICrdtDbContext> CreateDbContextAsync(CancellationToken cancellationToken = new CancellationToken());
+    ICrdtDbContext CreateDbContext();
+}
+
+public class CrdtDbContextFactoryNoContextFactory<TContext>(TContext dbContext) : ICrdtDbContextFactory
+    where TContext : ICrdtDbContext
+{
+    public Task<ICrdtDbContext> CreateDbContextAsync(CancellationToken cancellationToken = new CancellationToken())
+    {
+        return Task.FromResult<ICrdtDbContext>(new NoDisposeWrapper(dbContext));
+    }
+
+    public ICrdtDbContext CreateDbContext()
+    {
+        return new NoDisposeWrapper(dbContext);
+    }
+
+    private class NoDisposeWrapper(ICrdtDbContext context): ICrdtDbContext
+    {
+        public void Dispose()
+        {
+            //noop, don't dispose because the context is owned by the ioc container
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            //noop, don't dispose because the context is owned by the ioc container
+            return ValueTask.CompletedTask;
+        }
+
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            return context.SaveChangesAsync(cancellationToken);
+        }
+
+        public ValueTask<object?> FindAsync(Type entityType, params object?[]? keyValues)
+        {
+            return context.FindAsync(entityType, keyValues);
+        }
+
+        public DbSet<TEntity> Set<TEntity>() where TEntity : class
+        {
+            return context.Set<TEntity>();
+        }
+
+        public DatabaseFacade Database => context.Database;
+
+        public ChangeTracker ChangeTracker => context.ChangeTracker;
+
+        public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
+        {
+            return context.Entry(entity);
+        }
+
+        public EntityEntry Entry(object entity)
+        {
+            return context.Entry(entity);
+        }
+
+        public EntityEntry Add(object entity)
+        {
+            return context.Add(entity);
+        }
+
+        public void AddRange(IEnumerable<object> entities)
+        {
+            context.AddRange(entities);
+        }
+
+        public EntityEntry Remove(object entity)
+        {
+            return context.Remove(entity);
+        }
+    }
+}

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -1,17 +1,36 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Nito.AsyncEx;
 using SIL.Harmony.Changes;
 using SIL.Harmony.Resource;
 
 namespace SIL.Harmony.Db;
 
-internal class CrdtRepository
+internal class CrdtRepositoryFactory(IServiceProvider serviceProvider, ICrdtDbContextFactory dbContextFactory)
 {
+    public async Task<CrdtRepository> CreateRepository()
+    {
+        return ActivatorUtilities.CreateInstance<CrdtRepository>(serviceProvider, await dbContextFactory.CreateDbContextAsync());
+    }
+
+    public CrdtRepository CreateRepositorySync()
+    {
+        return ActivatorUtilities.CreateInstance<CrdtRepository>(serviceProvider, dbContextFactory.CreateDbContext());
+    }
+}
+
+internal class CrdtRepository : IDisposable, IAsyncDisposable
+{
+    private static readonly ConcurrentDictionary<string, AsyncLock> Locks = new();
+
+    private readonly AsyncLock _lock;
     private readonly ICrdtDbContext _dbContext;
     private readonly IOptions<CrdtConfig> _crdtConfig;
     private readonly ILogger<CrdtRepository> _logger;
@@ -26,6 +45,12 @@ internal class CrdtRepository
         //we can't use the scoped db context is it prevents access to the DbSet for the Snapshots,
         //but since we're using a custom query, we can use it directly and apply the scoped filters manually
         _currentSnapshotsQueryable = MakeCurrentSnapshotsQuery(dbContext, ignoreChangesAfter);
+        _lock = Locks.GetOrAdd(DatabaseIdentifier, _ => new AsyncLock());
+    }
+
+    public AwaitableDisposable<IDisposable> Lock()
+    {
+        return _lock.LockAsync();
     }
 
     /// <summary>
@@ -33,7 +58,7 @@ internal class CrdtRepository
     /// may be the connection string so it could contain sensitive information
     /// if it's in memory we'll just use a random guid
     /// </summary>
-    internal string DatabaseIdentifier
+    private string DatabaseIdentifier
     {
         get
         {
@@ -372,6 +397,16 @@ internal class CrdtRepository
     {
         return await _dbContext.Set<LocalResource>().FindAsync(resourceId);
     }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+    }
 }
 
 internal class ScopedDbContext(ICrdtDbContext inner, Commit ignoreChangesAfter) : ICrdtDbContext
@@ -421,5 +456,15 @@ internal class ScopedDbContext(ICrdtDbContext inner, Commit ignoreChangesAfter) 
     public EntityEntry Remove(object entity)
     {
         return inner.Remove(entity);
+    }
+
+    public void Dispose()
+    {
+        inner.Dispose();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return inner.DisposeAsync();
     }
 }

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -80,6 +80,13 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         }
     }
 
+    //doesn't really do anything when using a dbcontext factory since it will likely just have been created
+    //but when not using the factory it is still useful
+    internal void ClearChangeTracker()
+    {
+        _dbContext.ChangeTracker.Clear();
+    }
+
     private IQueryable<ObjectSnapshot> Snapshots => _dbContext.Snapshots.AsNoTracking();
 
     private IQueryable<Commit> Commits => _dbContext.Commits;

--- a/src/SIL.Harmony/Db/ICrdtDbContext.cs
+++ b/src/SIL.Harmony/Db/ICrdtDbContext.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace SIL.Harmony.Db;
 
-public interface ICrdtDbContext
+public interface ICrdtDbContext : IDisposable, IAsyncDisposable
 {
     IQueryable<Commit> Commits => Set<Commit>();
     IQueryable<ObjectSnapshot> Snapshots => Set<ObjectSnapshot>();

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -77,7 +77,7 @@ public class ResourceService
     public async Task<LocalResource[]> ListResourcesPendingUpload()
     {
         ValidateResourcesSetup();
-        var remoteResources = await _dataModel.QueryLatest<RemoteResource>().Where(r => r.RemoteId == null).ToArrayAsync();
+        var remoteResources = await _dataModel.QueryLatest<RemoteResource>(q => q.Where(r => r.RemoteId == null)).ToArrayAsync();
         var localResource = _crdtRepository.LocalResourcesByIds(remoteResources.Select(r => r.Id));
         return await localResource.ToArrayAsync();
     }
@@ -121,8 +121,8 @@ public class ResourceService
     {
         ValidateResourcesSetup();
         var localResourceIds = _crdtRepository.LocalResourceIds();
-        var remoteResources = await _dataModel.QueryLatest<RemoteResource>()
-            .Where(r => r.RemoteId != null && !localResourceIds.Contains(r.Id))
+        var remoteResources = await _dataModel
+            .QueryLatest<RemoteResource>(q => q.Where(r => r.RemoteId != null && !localResourceIds.Contains(r.Id)))
             .ToArrayAsync();
         return remoteResources;
     }


### PR DESCRIPTION
this is required for https://github.com/sillsdev/languageforge-lexbox/pull/1804

I've also removed deferring changes, and instead created the `AddManyChanges` api which will break up changes into commits based on a bucket size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for factory-based creation of repository and database context instances, improving resource management and flexibility.
  * Introduced batch change addition with a new method to efficiently commit multiple changes at once.

* **Refactor**
  * Refactored service registration and data model logic to use repository factories, removing shared state and enhancing scalability.
  * Updated query methods to support asynchronous streaming and projection.
  * Modified resource query filtering to embed predicates directly within queries for improved clarity.
  * Enhanced tests to fully enumerate query results before assertions, improving test reliability.

* **Bug Fixes**
  * Improved disposal and locking mechanisms for repositories and database contexts to ensure proper resource cleanup and thread safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->