### PR TITLE
Allow adding json type modifiers to object types

### DIFF
--- a/src/SIL.Harmony/Adapters/CustomAdapterProvider.cs
+++ b/src/SIL.Harmony/Adapters/CustomAdapterProvider.cs
@@ -18,7 +18,7 @@ public class CustomAdapterProvider<TCommonInterface, TCustomAdapter> : IObjectAd
         _objectTypeListBuilder = objectTypeListBuilder;
         JsonTypes.AddDerivedType(typeof(IObjectBase), typeof(TCustomAdapter), TCustomAdapter.TypeName);
     }
-    
+
     public CustomAdapterProvider<TCommonInterface, TCustomAdapter> AddWithCustomPolymorphicMapping<T>(string typeName,
         Action<EntityTypeBuilder<T>>? configureEntry = null
     ) where T : class, TCommonInterface
@@ -28,7 +28,8 @@ public class CustomAdapterProvider<TCommonInterface, TCustomAdapter> : IObjectAd
     }
 
     public CustomAdapterProvider<TCommonInterface, TCustomAdapter> Add<T>(
-        Action<EntityTypeBuilder<T>>? configureEntry = null
+        Action<EntityTypeBuilder<T>>? configureEntry = null,
+        Action<JsonTypeInfo>? jsonTypeModifier = null
     ) where T : class, TCommonInterface
     {
         _objectTypeListBuilder.CheckFrozen();
@@ -39,7 +40,7 @@ public class CustomAdapterProvider<TCommonInterface, TCustomAdapter> : IObjectAd
                     var entity = builder.Entity<T>();
                     configureEntry?.Invoke(entity);
                     return entity;
-                })
+                }, jsonTypeModifier)
         );
         return this;
     }

--- a/src/SIL.Harmony/Adapters/IObjectAdapterProvider.cs
+++ b/src/SIL.Harmony/Adapters/IObjectAdapterProvider.cs
@@ -1,9 +1,10 @@
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace SIL.Harmony.Adapters;
 
-internal record AdapterRegistration(Type ObjectDbType, Func<ModelBuilder, EntityTypeBuilder> EntityBuilder);
+internal record AdapterRegistration(Type ObjectDbType, Func<ModelBuilder, EntityTypeBuilder> EntityBuilder, Action<JsonTypeInfo>? JsonTypeModifier = null);
 
 internal interface IObjectAdapterProvider
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable per-type customization of JSON metadata during adapter registration, allowing finer control over serialization.
* **Refactor**
  * Introduced a cached registrations map used after configuration is frozen, ensuring consistent application of JSON modifiers and improving stability.
* **Style**
  * Minor formatting cleanups with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->