### PR TITLE
Pull updating commit hashes out of SnapshotWorker

### DIFF
--- a/src/SIL.Harmony.Core/CommitBase.cs
+++ b/src/SIL.Harmony.Core/CommitBase.cs
@@ -7,7 +7,7 @@ namespace SIL.Harmony.Core;
 /// most basic commit, does not contain any change data, that's stored in <see cref="CommitBase{TChange}"/>
 /// this class is not meant to be inherited from directly, use <see cref="ServerCommit"/> or <see cref="SIL.Harmony.Commit"/> instead
 /// </summary>
-public abstract class CommitBase
+public abstract class CommitBase : IComparable<CommitBase>
 {
     public const string NullParentHash = "0000";
     [JsonConstructor]
@@ -44,6 +44,12 @@ public abstract class CommitBase
     public override string ToString()
     {
         return $"{Id} [{DateTime}]";
+    }
+
+    public int CompareTo(CommitBase? other)
+    {
+        if (other is null) return 1;
+        return CompareKey.CompareTo(other.CompareKey);
     }
 }
 

--- a/src/SIL.Harmony.Core/QueryHelpers.cs
+++ b/src/SIL.Harmony.Core/QueryHelpers.cs
@@ -60,19 +60,18 @@ public static class QueryHelpers
         }
     }
 
-    private static readonly IComparer<CommitBase> CommitComparer =
-        Comparer<CommitBase>.Create((a, b) => a.CompareKey.CompareTo(b.CompareKey));
-
     public static SortedSet<T> ToSortedSet<T>(this IEnumerable<T> queryable) where T : CommitBase
     {
-        return new SortedSet<T>(queryable, CommitComparer);
+        return [.. queryable];
     }
 
     public static async Task<SortedSet<T>> ToSortedSetAsync<T>(this IQueryable<T> queryable) where T : CommitBase
     {
-        var set = new SortedSet<T>(CommitComparer);
+        var set = new SortedSet<T>();
         await foreach (var item in queryable.AsAsyncEnumerable())
+        {
             set.Add(item);
+        }
         return set;
     }
 

--- a/src/SIL.Harmony.Core/QueryHelpers.cs
+++ b/src/SIL.Harmony.Core/QueryHelpers.cs
@@ -60,6 +60,22 @@ public static class QueryHelpers
         }
     }
 
+    private static readonly IComparer<CommitBase> CommitComparer =
+        Comparer<CommitBase>.Create((a, b) => a.CompareKey.CompareTo(b.CompareKey));
+
+    public static SortedSet<T> ToSortedSet<T>(this IEnumerable<T> queryable) where T : CommitBase
+    {
+        return new SortedSet<T>(queryable, CommitComparer);
+    }
+
+    public static async Task<SortedSet<T>> ToSortedSetAsync<T>(this IQueryable<T> queryable) where T : CommitBase
+    {
+        var set = new SortedSet<T>(CommitComparer);
+        await foreach (var item in queryable.AsAsyncEnumerable())
+            set.Add(item);
+        return set;
+    }
+
     public static IQueryable<T> DefaultOrder<T>(this IQueryable<T> queryable) where T: CommitBase
     {
         return queryable

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -155,8 +155,7 @@ public class DataModel : ISyncable, IAsyncDisposable
             if (oldestChange is null || newCommits is []) return;
 
             await using var transaction = await repo.BeginTransactionAsync();
-            //don't save since UpdateSnapshots will also modify newCommits with hashes, so changes will be saved once that's done
-            var updatedCommits = await repo.AddCommits(newCommits, false);
+            var updatedCommits = await repo.AddCommits(newCommits);
             await UpdateSnapshots(repo, updatedCommits);
             await ValidateCommits(repo);
             await transaction.CommitAsync();

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -201,6 +201,7 @@ public class DataModel : ISyncable, IAsyncDisposable
         Dictionary<Guid, Guid?> snapshotLookup;
         if (commitsToApply.Count > 10)
         {
+            // Bulk-load relevant snapshots to minimize DB queries
             var entityIds = commitsToApply.SelectMany(c => c.ChangeEntities.Select(ce => ce.EntityId));
             snapshotLookup = await repo.CurrentSnapshots()
                 .Where(s => entityIds.Contains(s.EntityId))

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -242,7 +242,9 @@ public class DataModel : ISyncable, IAsyncDisposable
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.DeleteSnapshotsAndProjectedTables();
         repo.ClearChangeTracker();
-        var allCommits = await repo.CurrentCommits().AsNoTracking().ToSortedSetAsync();
+        var allCommits = await repo.CurrentCommits()
+            .Include(c => c.ChangeEntities)
+            .ToSortedSetAsync();
         await UpdateSnapshots(repo, allCommits);
     }
 

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -81,8 +81,8 @@ public class DataModel : ISyncable, IAsyncDisposable
         repo.ClearChangeTracker();
 
         await using var transaction = await repo.BeginTransactionAsync();
-        await repo.AddCommits(commits);
-        await UpdateSnapshots(repo, commits.First(), commits);
+        var updatedCommits = await repo.AddCommits(commits);
+        await UpdateSnapshots(repo, updatedCommits);
         await ValidateCommits(repo);
         await transaction.CommitAsync();
     }
@@ -119,8 +119,8 @@ public class DataModel : ISyncable, IAsyncDisposable
         repo.ClearChangeTracker();
 
         await using var transaction = repo.IsInTransaction ? null : await repo.BeginTransactionAsync();
-        await repo.AddCommit(commit);
-        await UpdateSnapshots(repo, commit, [commit]);
+        var updatedCommits = await repo.AddCommit(commit);
+        await UpdateSnapshots(repo, updatedCommits);
 
         if (AlwaysValidate) await ValidateCommits(repo);
 
@@ -156,8 +156,8 @@ public class DataModel : ISyncable, IAsyncDisposable
 
             await using var transaction = await repo.BeginTransactionAsync();
             //don't save since UpdateSnapshots will also modify newCommits with hashes, so changes will be saved once that's done
-            await repo.AddCommits(newCommits, false);
-            await UpdateSnapshots(repo, oldestChange, newCommits);
+            var updatedCommits = await repo.AddCommits(newCommits, false);
+            await UpdateSnapshots(repo, updatedCommits);
             await ValidateCommits(repo);
             await transaction.CommitAsync();
         }
@@ -194,13 +194,15 @@ public class DataModel : ISyncable, IAsyncDisposable
         return ValueTask.FromResult(true);
     }
 
-    private async Task UpdateSnapshots(CrdtRepository repo, Commit oldestAddedCommit, Commit[] newCommits)
+    private async Task UpdateSnapshots(CrdtRepository repo, SortedSet<Commit> commitsToApply)
     {
+        if (commitsToApply.Count == 0) return;
+        var oldestAddedCommit = commitsToApply.First();
         await repo.DeleteStaleSnapshots(oldestAddedCommit);
         Dictionary<Guid, Guid?> snapshotLookup;
-        if (newCommits.Length > 10)
+        if (commitsToApply.Count > 10)
         {
-            var entityIds = newCommits.SelectMany(c => c.ChangeEntities.Select(ce => ce.EntityId));
+            var entityIds = commitsToApply.SelectMany(c => c.ChangeEntities.Select(ce => ce.EntityId));
             snapshotLookup = await repo.CurrentSnapshots()
                 .Where(s => entityIds.Contains(s.EntityId))
                 .Select(s => new KeyValuePair<Guid, Guid?>(s.EntityId, s.Id))
@@ -212,7 +214,7 @@ public class DataModel : ISyncable, IAsyncDisposable
         }
 
         var snapshotWorker = new SnapshotWorker(snapshotLookup, repo, _crdtConfig.Value);
-        await snapshotWorker.UpdateSnapshots(oldestAddedCommit, newCommits);
+        await snapshotWorker.UpdateSnapshots(commitsToApply);
     }
 
     private async Task ValidateCommits(CrdtRepository repo)
@@ -240,8 +242,8 @@ public class DataModel : ISyncable, IAsyncDisposable
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.DeleteSnapshotsAndProjectedTables();
         repo.ClearChangeTracker();
-        var allCommits = await repo.CurrentCommits().AsNoTracking().ToArrayAsync();
-        await UpdateSnapshots(repo, allCommits.First(), allCommits);
+        var allCommits = await repo.CurrentCommits().AsNoTracking().ToSortedSetAsync();
+        await UpdateSnapshots(repo, allCommits);
     }
 
     public async Task<ObjectSnapshot> GetLatestSnapshotByObjectId(Guid entityId)
@@ -296,7 +298,7 @@ public class DataModel : ISyncable, IAsyncDisposable
         var repository = repo.GetScopedRepository(commit);
         var (snapshots, pendingCommits) = await repository.GetCurrentSnapshotsAndPendingCommits();
 
-        if (pendingCommits.Length != 0)
+        if (pendingCommits.Count != 0)
         {
             snapshots = await SnapshotWorker.ApplyCommitsToSnapshots(snapshots,
                 repository,
@@ -331,8 +333,8 @@ public class DataModel : ISyncable, IAsyncDisposable
         var newCommits = await repository.CurrentCommits()
             .Include(c => c.ChangeEntities)
             .WhereAfter(snapshot.Commit)
-            .ToArrayAsync();
-        if (newCommits.Length > 0)
+            .ToSortedSetAsync();
+        if (newCommits.Count > 0)
         {
             var snapshots = await SnapshotWorker.ApplyCommitsToSnapshots(
                 new Dictionary<Guid, ObjectSnapshot>([

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -382,10 +382,10 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         return updatedCommits;
     }
 
-    public async Task<SortedSet<Commit>> AddCommits(IEnumerable<Commit> commits, bool save = true)
+    public async Task<SortedSet<Commit>> AddCommits(IEnumerable<Commit> commits)
     {
         var updatedCommits = await AddNewCommits(commits);
-        if (save) await _dbContext.SaveChangesAsync();
+        await _dbContext.SaveChangesAsync();
         return updatedCommits;
     }
 

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -400,12 +400,12 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
             .UnionBy(newCommits, c => c.Id)
             .ToSortedSet();
         //we're inserting commits in the past/rewriting history, so we need to update the previous commit hashes
-        await UpdateCommitHashes(commitsToApply, parentCommit);
+        UpdateCommitHashes(commitsToApply, parentCommit);
         _dbContext.AddRange(newCommits);
         return commitsToApply;
     }
 
-    private async Task UpdateCommitHashes(SortedSet<Commit> commits, Commit? parentCommit = null)
+    private void UpdateCommitHashes(SortedSet<Commit> commits, Commit? parentCommit = null)
     {
         var previousCommitHash = parentCommit?.Hash ?? CommitBase.NullParentHash;
         foreach (var commit in commits)

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -375,6 +375,11 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         return new CrdtRepository(_dbContext, _crdtConfig, _logger, excludeChangesAfterCommit);
     }
 
+    /// <summary>
+    /// Adds a commit to the database. If the new commit was authored before any commits that
+    /// are already in the database, then history will be rewritten by updating those commit hashes.
+    /// </summary>
+    /// <returns>All added and updated commits.</returns>
     public async Task<SortedSet<Commit>> AddCommit(Commit commit)
     {
         var updatedCommits = await AddNewCommits([commit]);
@@ -382,6 +387,11 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         return updatedCommits;
     }
 
+    /// <summary>
+    /// Adds commits to the database. If any of the new commits were authored before any commits that
+    /// are already in the database, then history will be rewritten by updating those commit hashes.
+    /// </summary>
+    /// <returns>All added and updated commits.</returns>
     public async Task<SortedSet<Commit>> AddCommits(IEnumerable<Commit> commits)
     {
         var updatedCommits = await AddNewCommits(commits);

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -402,7 +402,6 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         //we're inserting commits in the past/rewriting history, so we need to update the previous commit hashes
         await UpdateCommitHashes(commitsToApply, parentCommit);
         _dbContext.AddRange(newCommits);
-        await _dbContext.SaveChangesAsync();
         return commitsToApply;
     }
 

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -402,6 +402,7 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         //we're inserting commits in the past/rewriting history, so we need to update the previous commit hashes
         await UpdateCommitHashes(commitsToApply, parentCommit);
         _dbContext.AddRange(newCommits);
+        await _dbContext.SaveChangesAsync();
         return commitsToApply;
     }
 
@@ -413,7 +414,6 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
             commit.SetParentHash(previousCommitHash);
             previousCommitHash = commit.Hash;
         }
-        await _dbContext.SaveChangesAsync();
     }
 
     public HybridDateTime? GetLatestDateTime()


### PR DESCRIPTION
Refactor to clean up some of https://github.com/sillsdev/harmony/pull/54

https://github.com/sillsdev/harmony/pull/54 introduced the possibility of a commit not generating any snapshots (by not generating a new snapshot if a change object was ignored, which happens in the edge case of a create-change being applied to an entity that already exists and is not deleted).

That change uncovered the fact, that we're relying on the call to `DbContext.SaveChangesAsync()` in `CrdtRepository.AddSnapshots()` to persist updates to commit hashes.
That's very subtle and is not a good separation of concerns.

This PR pulls that commit-hash-updating out of SnapshotWorker and does it immediately when commits are added to the db-context.

I also started making use of `SortedSet<Commit>`, so that collections of commits can be passed around without each method having to make sure they're sorted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Systemwide use of ordered commit collections for consistent ordering and snapshot processing.
  * Commit objects now support comparison to ensure reliable ordering when applied.
  * Snapshot and commit application flows updated to operate on ordered collections with improved asynchronous materialization of pending commits.
  * Add/commit operations now return the updated ordered commit set and include clearer error context for snapshot updates.

* **Tests**
  * New integrity test ensures corrupted commit parent hashes are detected and cause validation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->