### PR TITLE
git-ignore new c# DevKit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,5 @@ FodyWeavers.xsd
 
 #Verify
 *.received.*
+
+*.lscache


### PR DESCRIPTION
The C# DevKit got an update that generates these files, which are intended to be git ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude `.lscache` files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->