### PR TITLE
Update to .NET 10, bump NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,26 +3,26 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0-alpha.6" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="JetBrains.Profiler.SelfApi" Version="2.5.12" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageVersion Include="JetBrains.Profiler.SelfApi" Version="2.5.18" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.EntityFramework" Version="12.4.0" />
-    <PackageVersion Include="Verify.Xunit" Version="28.2.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19" />
-    <PackageVersion Include="linq2db.AspNet" Version="5.4.1" />
-    <PackageVersion Include="linq2db.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Verify.EntityFramework" Version="15.1.0" />
+    <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+    <PackageVersion Include="linq2db.AspNet" Version="5.4.1.9" />
+    <PackageVersion Include="linq2db.EntityFrameworkCore" Version="10.3.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,12 +17,13 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.EntityFramework" Version="15.1.0" />
-    <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.16.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
-    <PackageVersion Include="linq2db.AspNet" Version="5.4.1.9" />
+    <PackageVersion Include="linq2db" Version="6.2.1" />
     <PackageVersion Include="linq2db.EntityFrameworkCore" Version="10.3.0" />
+    <PackageVersion Include="linq2db.Extensions" Version="6.2.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.0.0" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
         <Nullable>enable</Nullable>

--- a/src/SIL.Harmony.Linq2db/Linq2dbKernel.cs
+++ b/src/SIL.Harmony.Linq2db/Linq2dbKernel.cs
@@ -1,6 +1,6 @@
 ﻿using SIL.Harmony.Core;
-using LinqToDB.AspNet.Logging;
 using LinqToDB.EntityFrameworkCore;
+using LinqToDB.Extensions.Logging;
 using LinqToDB.Mapping;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/SIL.Harmony.Linq2db/SIL.Harmony.Linq2db.csproj
+++ b/src/SIL.Harmony.Linq2db/SIL.Harmony.Linq2db.csproj
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="linq2db.AspNet" />
       <PackageReference Include="linq2db.EntityFrameworkCore" />
+      <PackageReference Include="linq2db.Extensions" />
     </ItemGroup>
 
 </Project>

--- a/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
+++ b/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
@@ -158,8 +158,8 @@ public class CustomObjectAdapterTests
                     .Add<MyClass2>(builder => builder.HasKey(o => o.Identifier));
             }).BuildServiceProvider();
         var myDbContext = services.GetRequiredService<MyDbContext>();
-        await myDbContext.Database.OpenConnectionAsync();
-        await myDbContext.Database.EnsureCreatedAsync();
+        await myDbContext.Database.OpenConnectionAsync(TestContext.Current.CancellationToken);
+        await myDbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
         var dataModel = services.GetRequiredService<DataModel>();
         var objectId = Guid.NewGuid();
         var objectId2 = Guid.NewGuid();
@@ -194,6 +194,6 @@ public class CustomObjectAdapterTests
         myClass2.MyNumber.Should().Be(123.45m);
         myClass2.DeletedTime.Should().BeNull();
 
-        dataModel.QueryLatest<MyClass>().ToBlockingEnumerable().Should().NotBeEmpty();
+        dataModel.QueryLatest<MyClass>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Should().NotBeEmpty();
     }
 }

--- a/src/SIL.Harmony.Tests/DataModelPerformanceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelPerformanceTests.cs
@@ -11,7 +11,6 @@ using JetBrains.Profiler.SelfApi;
 using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
 using SIL.Harmony.Sample.Changes;
-using Xunit.Abstractions;
 
 namespace SIL.Harmony.Tests;
 

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -10,7 +10,7 @@ public class DataModelReferenceTests : DataModelTestBase
     private readonly Guid _word1Id = Guid.NewGuid();
     private readonly Guid _word2Id = Guid.NewGuid();
 
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         await WriteNextChange(SetWord(_word1Id, "entity1"));

--- a/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
+++ b/src/SIL.Harmony.Tests/DataModelReferenceTests.cs
@@ -41,7 +41,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.AntonymId.Should().Be(_word2Id);
         entityWord.Antonym.Should().NotBeNull();
@@ -80,7 +80,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == word3Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == word3Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.AntonymId.Should().Be(_word2Id);
         entityWord.Antonym.Should().NotBeNull();
@@ -118,7 +118,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == word3Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == word3Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.AntonymId.Should().Be(_word2Id);
         entityWord.Antonym.Should().NotBeNull();
@@ -157,7 +157,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == word3Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == word3Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.Text.Should().Be("entity3");
         entityWord.AntonymId.Should().Be(_word1Id);
@@ -197,7 +197,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.Text.Should().Be("entity1");
         entityWord.AntonymId.Should().Be(word3Id);
@@ -236,7 +236,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == word3Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == word3Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.Text.Should().Be("entity3");
         entityWord.AntonymId.Should().Be(_word1Id);
@@ -275,7 +275,7 @@ public class DataModelReferenceTests : DataModelTestBase
 
         // assert - projected entity
         var entityWord = await DataModel.QueryLatest<Word>(w => w.Include(w => w.Antonym))
-            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync();
+            .Where(w => w.Id == _word1Id).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.Text.Should().Be("entity1");
         entityWord.AntonymId.Should().Be(word3Id);
@@ -341,10 +341,10 @@ public class DataModelReferenceTests : DataModelTestBase
             initialWordCommit,
             deleteWordCommit
         ]);
-        var snapshot = await DbContext.Snapshots.SingleAsync(s => s.CommitId == initialWordCommit.Id);
+        var snapshot = await DbContext.Snapshots.SingleAsync(s => s.CommitId == initialWordCommit.Id, TestContext.Current.CancellationToken);
         var initialWord = (Word) snapshot.Entity;
         initialWord.AntonymId.Should().Be(_word1Id);
-        snapshot = await DbContext.Snapshots.SingleAsync(s => s.CommitId == deleteWordCommit.Id && s.EntityId == wordId);
+        snapshot = await DbContext.Snapshots.SingleAsync(s => s.CommitId == deleteWordCommit.Id && s.EntityId == wordId, TestContext.Current.CancellationToken);
         var wordWithoutRef = (Word) snapshot.Entity;
         wordWithoutRef.AntonymId.Should().BeNull();
     }
@@ -422,7 +422,7 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteChangeBefore(commitA, SetTag(Guid.NewGuid(), tagText));
-        DataModel.QueryLatest<Tag>().ToBlockingEnumerable().Where(t => t.Text == tagText).Should().ContainSingle();
+        DataModel.QueryLatest<Tag>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Where(t => t.Text == tagText).Should().ContainSingle();
     }
 
     [Fact]
@@ -434,6 +434,6 @@ public class DataModelReferenceTests : DataModelTestBase
         var commitA = await WriteNextChange(SetTag(Guid.NewGuid(), tagText));
         //represents someone syncing in a tag with the same name
         await WriteNextChange(SetTag(renameTagId, tagText));
-        DataModel.QueryLatest<Tag>().ToBlockingEnumerable().Where(t => t.Text == tagText).Should().ContainSingle();
+        DataModel.QueryLatest<Tag>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Where(t => t.Text == tagText).Should().ContainSingle();
     }
 }

--- a/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
+++ b/src/SIL.Harmony.Tests/DataModelSimpleChanges.cs
@@ -77,7 +77,7 @@ public class DataModelSimpleChanges : DataModelTestBase
 
         await WriteNextChange(SetWord(Guid.NewGuid(), "change 3"));
         DbContext.Snapshots.Should().HaveCount(3);
-        DataModel.QueryLatest<Word>().ToBlockingEnumerable().Should().HaveCount(3);
+        DataModel.QueryLatest<Word>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Should().HaveCount(3);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class DataModelSimpleChanges : DataModelTestBase
     {
         await WriteNextChange(SetWord(_entity1Id, "first"));
         await WriteNextChange(SetWord(_entity1Id, "second"));
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         snapshot.Entity.Is<Word>().Text.Should().Be("second");
     }
 
@@ -107,7 +107,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         await WriteNextChange(SetWord(_entity1Id, "word-1"));
         await WriteNextChange(SetWord(_entity1Id, "second"));
         await WriteNextChange(SetWord(_entity1Id, "third"));
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         snapshot.Entity.Is<Word>().Text.Should().Be("third");
     }
 
@@ -118,7 +118,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         var secondDate = DateTimeOffset.UtcNow.AddSeconds(1);
         await WriteChange(_localClientId, firstDate, SetWord(_entity1Id, "first"));
         await WriteChange(_localClientId, secondDate, SetWord(_entity1Id, "second"));
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         snapshot.Entity.Is<Word>().Text.Should().Be("second");
     }
 
@@ -129,7 +129,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         var secondDate = DateTimeOffset.Now.AddSeconds(1);
         await WriteChange(_localClientId, firstDate, SetWord(_entity1Id, "first"));
         await WriteChange(_localClientId, secondDate, SetWord(_entity1Id, "second"));
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         snapshot.Entity.Is<Word>().Text.Should().Be("second");
     }
 
@@ -185,7 +185,7 @@ public class DataModelSimpleChanges : DataModelTestBase
     {
         await WriteNextChange(SetWord(_entity1Id, "test-value"));
         var deleteCommit = await WriteNextChange(new DeleteChange<Word>(_entity1Id));
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         snapshot.Entity.DeletedAt.Should().Be(deleteCommit.DateTime);
     }
 
@@ -198,7 +198,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         newNoteChange.SupportsApplyChange().Should().BeTrue();
         newNoteChange.SupportsNewEntity().Should().BeFalse(); // otherwise it will override the delete
         await WriteNextChange(newNoteChange);
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         var word = snapshot.Entity.Is<Word>();
         word.Text.Should().Be("test-value");
         word.Note.Should().Be("note-after-delete");
@@ -213,7 +213,7 @@ public class DataModelSimpleChanges : DataModelTestBase
         var recreateChange = SetWord(_entity1Id, "after-undo-delete");
         recreateChange.SupportsNewEntity().Should().BeTrue();
         await WriteNextChange(recreateChange);
-        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync();
+        var snapshot = await DbContext.Snapshots.DefaultOrder().LastAsync(TestContext.Current.CancellationToken);
         var word = snapshot.Entity.Is<Word>();
         word.Text.Should().Be("after-undo-delete");
         word.DeletedAt.Should().Be(null);

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -161,12 +161,12 @@ public class DataModelTestBase : IAsyncLifetime
         };
     }
 
-    public virtual Task InitializeAsync()
+    public virtual ValueTask InitializeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
 
         await _services.DisposeAsync();

--- a/src/SIL.Harmony.Tests/DataQueryTests.cs
+++ b/src/SIL.Harmony.Tests/DataQueryTests.cs
@@ -15,7 +15,7 @@ public class DataQueryTests: DataModelTestBase
     [Fact]
     public async Task CanQueryLatestData()
     {
-        var entries = await DataModel.QueryLatest<Word>().ToArrayAsync();
+        var entries = await DataModel.QueryLatest<Word>().ToArrayAsync(TestContext.Current.CancellationToken);
         var entry = entries.Should().ContainSingle().Subject;
         entry.Text.Should().Be("entity1");
     }

--- a/src/SIL.Harmony.Tests/DataQueryTests.cs
+++ b/src/SIL.Harmony.Tests/DataQueryTests.cs
@@ -6,7 +6,7 @@ namespace SIL.Harmony.Tests;
 public class DataQueryTests: DataModelTestBase
 {
     private readonly Guid _entity1Id = Guid.NewGuid();
-    public override async Task InitializeAsync()
+    public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
         await WriteNextChange(SetWord(_entity1Id, "entity1"));

--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -24,7 +24,6 @@
     Keys: 
       Id PK
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -44,7 +43,6 @@
     Foreign keys: 
       ChangeEntity<IChange> {'CommitId'} -> Commit {'Id'} Required Cascade ToDependent: ChangeEntities
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -66,7 +64,7 @@
           ElementType: Element type: Guid Required
       TypeName (string) Required
     Navigations: 
-      Commit (Commit) ToPrincipal Commit Inverse: Snapshots
+      Commit (Commit) Required ToPrincipal Commit Inverse: Snapshots
     Keys: 
       Id PK
     Foreign keys: 
@@ -75,7 +73,6 @@
       EntityId
       CommitId, EntityId Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -89,7 +86,6 @@
     Keys: 
       Id PK
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -109,7 +105,6 @@
     Indexes: 
       SnapshotId Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -135,7 +130,6 @@
       SnapshotId Unique
       WordId
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -156,7 +150,6 @@
     Indexes: 
       SnapshotId Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -179,7 +172,6 @@
       SnapshotId Unique
       Text Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -196,7 +188,7 @@
       SnapshotId (no field, Guid?) Shadow FK Index
       Text (string) Required
     Navigations: 
-      Antonym (Word) ToPrincipal Word
+      Antonym (Word) Optional ToPrincipal Word
     Skip navigations: 
       Tags (List<Tag>) CollectionTag Inverse: Word
     Keys: 
@@ -208,7 +200,6 @@
       AntonymId
       SnapshotId Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -233,7 +224,6 @@
       TagId
       WordId, TagId Unique
     Annotations: 
-      DiscriminatorProperty: 
       Relational:FunctionName: 
       Relational:Schema: 
       Relational:SqlQuery: 
@@ -241,4 +231,4 @@
       Relational:ViewName: 
       Relational:ViewSchema: 
 Annotations: 
-  ProductVersion: 9.0.4
+  ProductVersion: 10.0.7

--- a/src/SIL.Harmony.Tests/DbContextTests.cs
+++ b/src/SIL.Harmony.Tests/DbContextTests.cs
@@ -27,10 +27,10 @@ public class DbContextTests: DataModelTestBase
             HybridDateTime = new HybridDateTime(expectedDateTime, 0)
         };
         DbContext.Add(commit);
-        await DbContext.SaveChangesAsync();
-        var actualCommit = await DbContext.Commits.AsNoTracking().SingleOrDefaultAsyncEF(c => c.Id == commitId);
+        await DbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var actualCommit = await DbContext.Commits.AsNoTracking().SingleOrDefaultAsyncEF(c => c.Id == commitId, TestContext.Current.CancellationToken);
         actualCommit!.HybridDateTime.DateTime.Should().Be(expectedDateTime, "EF");
-        actualCommit = await DbContext.Commits.ToLinqToDB().SingleOrDefaultAsyncLinqToDB(c => c.Id == commitId);
+        actualCommit = await DbContext.Commits.ToLinqToDB().SingleOrDefaultAsyncLinqToDB(c => c.Id == commitId, TestContext.Current.CancellationToken);
         actualCommit!.HybridDateTime.DateTime.Should().Be(expectedDateTime, "LinqToDB");
     }
 
@@ -53,10 +53,10 @@ public class DbContextTests: DataModelTestBase
             .Value(c => c.Metadata, new CommitMetadata())
             .Value(c => c.Hash, "")
             .Value(c => c.ParentHash, "")
-            .InsertAsync();
-        var actualCommit = await DbContext.Commits.SingleOrDefaultAsyncEF(c => c.Id == commitId);
+            .InsertAsync(TestContext.Current.CancellationToken);
+        var actualCommit = await DbContext.Commits.SingleOrDefaultAsyncEF(c => c.Id == commitId, TestContext.Current.CancellationToken);
         actualCommit!.HybridDateTime.DateTime.Should().Be(expectedDateTime, "EF");
-        actualCommit = await DbContext.Commits.ToLinqToDB().SingleOrDefaultAsyncLinqToDB(c => c.Id == commitId);
+        actualCommit = await DbContext.Commits.ToLinqToDB().SingleOrDefaultAsyncLinqToDB(c => c.Id == commitId, TestContext.Current.CancellationToken);
         actualCommit!.HybridDateTime.DateTime.Should().Be(expectedDateTime, "LinqToDB");
     }
 
@@ -80,11 +80,11 @@ public class DbContextTests: DataModelTestBase
             });
         }
 
-        await DbContext.SaveChangesAsync();
+        await DbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         var commits = await DbContext.Commits
             .Where(c => c.HybridDateTime.DateTime > baseDateTime.Add(new TimeSpan((long)(25 * scale))))
             .OrderBy(c => c.HybridDateTime.DateTime)
-            .ToArrayAsyncEF();
+            .ToArrayAsyncEF(TestContext.Current.CancellationToken);
         commits.Should().HaveCount(24);
     }
 }

--- a/src/SIL.Harmony.Tests/DefinitionTests.cs
+++ b/src/SIL.Harmony.Tests/DefinitionTests.cs
@@ -50,7 +50,7 @@ public class DefinitionTests : DataModelTestBase
         await WriteNextChange(NewDefinition(wordId, "greet someone", "verb", 2));
         await WriteNextChange(NewDefinition(wordId, "a greeting", "noun", 1));
 
-        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync();
+        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync(TestContext.Current.CancellationToken);
         definitions.Select(d => d.PartOfSpeech).Should().ContainInConsecutiveOrder(
             "noun",
             "verb"
@@ -69,7 +69,7 @@ public class DefinitionTests : DataModelTestBase
         await WriteNextChange(NewDefinition(wordId, "greet someone", "verb", 2, definitionBId));
         await WriteNextChange(NewDefinition(wordId, "used as a greeting", "exclamation", 3, definitionCId));
 
-        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync();
+        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync(TestContext.Current.CancellationToken);
         definitions.Select(d => d.PartOfSpeech).Should().ContainInConsecutiveOrder(
             "noun",
             "verb",
@@ -79,7 +79,7 @@ public class DefinitionTests : DataModelTestBase
         //change the order of the exclamation to be between the noun and verb
         await WriteNextChange(SetOrderChange<Definition>.Between(definitionCId, definitions[0], definitions[1]));
 
-        definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync();
+        definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync(TestContext.Current.CancellationToken);
         definitions.Select(d => d.PartOfSpeech).Should().ContainInConsecutiveOrder(
             "noun",
             "exclamation",
@@ -98,7 +98,7 @@ public class DefinitionTests : DataModelTestBase
         await WriteNextChange(NewDefinition(wordId, "greet someone", "verb", 1, definitionAId));
         await WriteNextChange(NewDefinition(wordId, "a greeting", "noun", 1, definitionBId));
 
-        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync();
+        var definitions = await DataModel.QueryLatest<Definition>().ToArrayAsync(TestContext.Current.CancellationToken);
         definitions.Select(d => d.Id).Should().ContainInConsecutiveOrder(
             definitionBId,
             definitionAId

--- a/src/SIL.Harmony.Tests/DeleteAndCreateTests.cs
+++ b/src/SIL.Harmony.Tests/DeleteAndCreateTests.cs
@@ -25,7 +25,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -48,7 +48,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -72,7 +72,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -96,7 +96,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -119,7 +119,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -141,7 +141,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("Undeleted");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("Undeleted");
@@ -163,7 +163,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().NotBeNull();
         word.Text.Should().Be("original");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().BeNull();
     }
 
@@ -182,7 +182,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().NotBeNull();
         word.Text.Should().Be("original");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().BeNull();
     }
 
@@ -192,7 +192,7 @@ public class DeleteAndCreateTests : DataModelTestBase
         var wordId = Guid.NewGuid();
 
         await WriteNextChange(new NewWordChange(wordId, "original"));
-        var snapshotsBefore = await DbContext.Snapshots.Where(s => s.EntityId == wordId).ToArrayAsync();
+        var snapshotsBefore = await DbContext.Snapshots.Where(s => s.EntityId == wordId).ToArrayAsync(TestContext.Current.CancellationToken);
 
         await WriteNextChange(
             [
@@ -204,12 +204,12 @@ public class DeleteAndCreateTests : DataModelTestBase
         word.DeletedAt.Should().BeNull();
         word.Text.Should().Be("original");
 
-        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync();
+        var entityWord = await DataModel.QueryLatest<Word>().Where(w => w.Id == wordId).SingleOrDefaultAsync(TestContext.Current.CancellationToken);
         entityWord.Should().NotBeNull();
         entityWord.DeletedAt.Should().BeNull();
         entityWord.Text.Should().Be("original");
 
-        var snapshotsAfter = await DbContext.Snapshots.Where(s => s.EntityId == wordId).ToArrayAsync();
+        var snapshotsAfter = await DbContext.Snapshots.Where(s => s.EntityId == wordId).ToArrayAsync(TestContext.Current.CancellationToken);
         snapshotsAfter.Select(s => s.Id).Should().BeEquivalentTo(snapshotsBefore.Select(s => s.Id));
     }
 }

--- a/src/SIL.Harmony.Tests/ModelSnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/ModelSnapshotTests.cs
@@ -129,7 +129,7 @@ public class ModelSnapshotTests : DataModelTestBase
 
         var latestSnapshot = await DataModel.GetLatestSnapshotByObjectId(entityId);
         //delete snapshots so when we get at then we need to re-apply
-        await DbContext.Snapshots.Where(s => !s.IsRoot).ExecuteDeleteAsync();
+        await DbContext.Snapshots.Where(s => !s.IsRoot).ExecuteDeleteAsync(TestContext.Current.CancellationToken);
 
         var computedModelSnapshots = await DataModel.GetSnapshotsAtCommit(latestSnapshot.Commit);
 

--- a/src/SIL.Harmony.Tests/ModelSnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/ModelSnapshotTests.cs
@@ -83,7 +83,7 @@ public class ModelSnapshotTests : DataModelTestBase
 
     private Task ClearNonRootSnapshots()
     {
-        return DbContext.Snapshots.Where(s => !s.IsRoot).ExecuteDeleteAsync();
+        return DbContext.Snapshots.Where(s => !s.IsRoot).ExecuteDeleteAsync(TestContext.Current.CancellationToken);
     }
 
     [Theory]

--- a/src/SIL.Harmony.Tests/MultiThreadingTests.cs
+++ b/src/SIL.Harmony.Tests/MultiThreadingTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Data.Sqlite;
-using Xunit.Abstractions;
 
 namespace SIL.Harmony.Tests;
 
@@ -17,7 +16,7 @@ public class MultiThreadingTests(ITestOutputHelper output)
             {
                 var random = new Random();
                 var fixture = new DataModelTestBase(new SqliteConnection(_connectionString));
-                fixture.InitializeAsync().Wait();
+                fixture.InitializeAsync().AsTask().Wait();
                 var id = Guid.NewGuid();
                 for (var i = 0; i < 100; i++)
                 {

--- a/src/SIL.Harmony.Tests/MultiThreadingTests.cs
+++ b/src/SIL.Harmony.Tests/MultiThreadingTests.cs
@@ -16,7 +16,7 @@ public class MultiThreadingTests(ITestOutputHelper output)
             {
                 var random = new Random();
                 var fixture = new DataModelTestBase(new SqliteConnection(_connectionString));
-                fixture.InitializeAsync().AsTask().Wait();
+                fixture.InitializeAsync().GetAwaiter().GetResult();
                 var id = Guid.NewGuid();
                 for (var i = 0; i < 100; i++)
                 {

--- a/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
+++ b/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
@@ -76,7 +76,7 @@ public class PersistExtraDataTests
     {
         var entityId = Guid.NewGuid();
         var commit = await _dataModelTestBase.WriteNextChange(new CreateExtraDataModelChange(entityId));
-        var extraDataModel = _dataModelTestBase.DataModel.QueryLatest<ExtraDataModel>().ToBlockingEnumerable().Should().ContainSingle().Subject;
+        var extraDataModel = _dataModelTestBase.DataModel.QueryLatest<ExtraDataModel>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Should().ContainSingle().Subject;
         extraDataModel.Id.Should().Be(entityId);
         extraDataModel.CommitId.Should().Be(commit.Id);
         extraDataModel.DateTime.Should().Be(commit.HybridDateTime.DateTime);

--- a/src/SIL.Harmony.Tests/RepositoryTests.cs
+++ b/src/SIL.Harmony.Tests/RepositoryTests.cs
@@ -115,7 +115,7 @@ public class RepositoryTests : IAsyncLifetime
             Commit(Guid.NewGuid(), commit1Time),
             Commit(Guid.NewGuid(), commit2Time),
         ]);
-        var commits = await _repository.CurrentCommits().ToArrayAsync();
+        var commits = await _repository.CurrentCommits().ToArrayAsync(TestContext.Current.CancellationToken);
         commits.Select(c => c.HybridDateTime).Should().ContainInConsecutiveOrder(commit1Time, commit2Time);
     }
 
@@ -128,7 +128,7 @@ public class RepositoryTests : IAsyncLifetime
             Commit(Guid.NewGuid(), commit1Time),
             Commit(Guid.NewGuid(), commit2Time),
         ]);
-        var commits = await _repository.CurrentCommits().ToArrayAsync();
+        var commits = await _repository.CurrentCommits().ToArrayAsync(TestContext.Current.CancellationToken);
         commits.Select(c => c.HybridDateTime).Should().ContainInConsecutiveOrder(commit1Time, commit2Time);
     }
 
@@ -141,7 +141,7 @@ public class RepositoryTests : IAsyncLifetime
             Commit(ids[0], commitTime),
             Commit(ids[1], commitTime),
         ]);
-        var commits = await _repository.CurrentCommits().ToArrayAsync();
+        var commits = await _repository.CurrentCommits().ToArrayAsync(TestContext.Current.CancellationToken);
         commits.Select(c => c.Id).Should().ContainInConsecutiveOrder(ids);
     }
 
@@ -149,7 +149,7 @@ public class RepositoryTests : IAsyncLifetime
     public async Task CurrentSnapshots_Works()
     {
         await _repository.AddSnapshots([Snapshot(Guid.NewGuid(), Guid.NewGuid(), Time(1, 0))]);
-        var snapshots = await _repository.CurrentSnapshots().ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().ContainSingle();
     }
 
@@ -162,7 +162,7 @@ public class RepositoryTests : IAsyncLifetime
             Snapshot(entityId, Guid.NewGuid(), Time(1, 0)),
             Snapshot(entityId, Guid.NewGuid(), expectedTime),
         ]);
-        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().ContainSingle().Which.Commit.HybridDateTime.Should().BeEquivalentTo(expectedTime);
     }
 
@@ -174,7 +174,7 @@ public class RepositoryTests : IAsyncLifetime
             Snapshot(entityId, Guid.NewGuid(), Time(1, 0)),
             Snapshot(entityId, Guid.NewGuid(), Time(1, 1)),
         ]);
-        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().ContainSingle().Which.Commit.HybridDateTime.Counter.Should().Be(1);
     }
 
@@ -188,7 +188,7 @@ public class RepositoryTests : IAsyncLifetime
             Snapshot(entityId, ids[0], time),
             Snapshot(entityId, ids[1], time),
         ]);
-        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().ContainSingle().Which.Commit.Id.Should().Be(ids[1]);
     }
 
@@ -207,12 +207,12 @@ public class RepositoryTests : IAsyncLifetime
             snapshot2,
         ]);
 
-        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         var commit = snapshots.Should().ContainSingle().Subject.Commit;
         commit.Id.Should().Be(commitIds[2]);
 
         snapshots = await _repository.GetScopedRepository(snapshot2.Commit).CurrentSnapshots().Include(s => s.Commit)
-            .ToArrayAsync();
+            .ToArrayAsync(TestContext.Current.CancellationToken);
         commit = snapshots.Should().ContainSingle().Subject.Commit;
         commit.Id.Should().Be(commitIds[1], $"commit order: [{string.Join(", ", commitIds)}]");
     }
@@ -232,11 +232,11 @@ public class RepositoryTests : IAsyncLifetime
             snapshot2,
         ]);
 
-        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        var snapshots = await _repository.CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         var commit = snapshots.Should().ContainSingle().Subject.Commit;
         commit.Id.Should().Be(commitIds[2]);
 
-        snapshots = await _repository.GetScopedRepository(snapshot2.Commit).CurrentSnapshots().Include(s => s.Commit).ToArrayAsync();
+        snapshots = await _repository.GetScopedRepository(snapshot2.Commit).CurrentSnapshots().Include(s => s.Commit).ToArrayAsync(TestContext.Current.CancellationToken);
         commit = snapshots.Should().ContainSingle().Subject.Commit;
         commit.Id.Should().Be(commitIds[1], $"commit order: [{string.Join(", ", commitIds)}]");
     }

--- a/src/SIL.Harmony.Tests/RepositoryTests.cs
+++ b/src/SIL.Harmony.Tests/RepositoryTests.cs
@@ -25,14 +25,14 @@ public class RepositoryTests : IAsyncLifetime
         _crdtDbContext = _services.GetRequiredService<SampleDbContext>();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Open the connection manually, otherwise it will be closed after each command, wiping out the in memory sqlite db
         await _crdtDbContext.Database.OpenConnectionAsync();
         await _crdtDbContext.Database.EnsureCreatedAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _repository.DisposeAsync();
         await _services.DisposeAsync();

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -128,7 +128,7 @@ public class RemoteResourcesTests : DataModelTestBase
 
 
         localResource.Id.Should().Be(resourceId);
-        var actualFileContents = await File.ReadAllTextAsync(localResource.LocalPath);
+        var actualFileContents = await File.ReadAllTextAsync(localResource.LocalPath, TestContext.Current.CancellationToken);
         actualFileContents.Should().Be(fileContents);
         var pendingDownloads = await _resourceService.ListResourcesPendingDownload();
         pendingDownloads.Should().BeEmpty();

--- a/src/SIL.Harmony.Tests/ResourceTests/WordResourceTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/WordResourceTests.cs
@@ -36,6 +36,6 @@ public class WordResourceTests: DataModelTestBase
         var localResource = await _resourceService.GetLocalResource(word.ImageResourceId!.Value);
         localResource.Should().NotBeNull();
         localResource!.LocalPath.Should().Be(imageFile);
-        (await File.ReadAllTextAsync(localResource.LocalPath)).Should().Be("not image data");
+        (await File.ReadAllTextAsync(localResource.LocalPath, TestContext.Current.CancellationToken)).Should().Be("not image data");
     }
 }

--- a/src/SIL.Harmony.Tests/SIL.Harmony.Tests.csproj
+++ b/src/SIL.Harmony.Tests/SIL.Harmony.Tests.csproj
@@ -17,8 +17,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Verify.DiffPlex" />
         <PackageReference Include="Verify.EntityFramework" />
-        <PackageReference Include="Verify.Xunit" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="Verify.XunitV3" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -28,6 +28,8 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="System.Linq.Async"/>
+        <PackageReference Include="linq2db" />
+        <PackageReference Include="linq2db.Extensions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SIL.Harmony.Tests/SIL.Harmony.Tests.csproj
+++ b/src/SIL.Harmony.Tests/SIL.Harmony.Tests.csproj
@@ -9,9 +9,9 @@
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.Testing.Platform" />
         <PackageReference Include="GitHubActionsTestLogger">
           <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="JetBrains.Profiler.SelfApi" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -31,7 +31,7 @@ public class SnapshotTests : DataModelTestBase
 
         await AddCommitsViaSync(commits);
 
-        var snapshots = await DbContext.Snapshots.ToArrayAsync();
+        var snapshots = await DbContext.Snapshots.ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().HaveCountGreaterThan(1);
         snapshots.Should().ContainSingle(s => s.IsRoot);
     }
@@ -52,7 +52,7 @@ public class SnapshotTests : DataModelTestBase
         await AddCommitsViaSync(commits);
 
         var latestSnapshot = await DataModel.GetLatestSnapshotByObjectId(entityId);
-        var snapshots = await DbContext.Snapshots.ToArrayAsync();
+        var snapshots = await DbContext.Snapshots.ToArrayAsync(TestContext.Current.CancellationToken);
         snapshots.Should().HaveCountGreaterThan(2);
         snapshots.Should().ContainSingle(s => s.Id == latestSnapshot.Id);
         snapshots.Should().ContainSingle(s => s.IsRoot);
@@ -119,7 +119,7 @@ public class SnapshotTests : DataModelTestBase
             ]);
 
         var word = await DataModel.QueryLatest<Word>(q => q.Include(w => w.Tags)
-            .Where(w => w.Id == wordId)).FirstOrDefaultAsync();
+            .Where(w => w.Id == wordId)).FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         word.Should().NotBeNull();
         word.Tags.Should().BeEquivalentTo([new Tag { Id = tagId, Text = "tag-1" }]);
     }
@@ -138,7 +138,7 @@ public class SnapshotTests : DataModelTestBase
         await WriteChangeBefore(tagCreation, TagWord(wordId, tagId));
 
         var word = await DataModel.QueryLatest<Word>(q => q.Include(w => w.Tags)
-            .Where(w => w.Id == wordId)).FirstOrDefaultAsync();
+            .Where(w => w.Id == wordId)).FirstOrDefaultAsync(TestContext.Current.CancellationToken);
         word.Should().NotBeNull();
         word.Tags.Should().BeEquivalentTo([new Tag { Id = tagId, Text = "tag-1" }]);
     }
@@ -151,13 +151,13 @@ public class SnapshotTests : DataModelTestBase
         await WriteNextChange(SetWord(entityId, "test1"));
         await WriteNextChange(SetWord(entityId, "test2"));
         await WriteNextChange(SetWord(entityId, "test3"));
-        var beforeSnapshotIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync();
-        var beforeRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync();
+        var beforeSnapshotIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync(TestContext.Current.CancellationToken);
+        var beforeRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync(TestContext.Current.CancellationToken);
 
         await DataModel.RegenerateSnapshots();
 
-        var afterRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync();
-        var afterSnapshotsIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync();
+        var afterRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync(TestContext.Current.CancellationToken);
+        var afterSnapshotsIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync(TestContext.Current.CancellationToken);
         afterRegenerate.Should().BeEquivalentTo(beforeRegenerate);
 
         //we probably won't have the same number of snapshots, which is ok. but none of the ids should be the same

--- a/src/SIL.Harmony.Tests/SyncTests.cs
+++ b/src/SIL.Harmony.Tests/SyncTests.cs
@@ -116,7 +116,7 @@ public class SyncTests : IAsyncLifetime
 
         await _client2.DataModel.SyncWith(_client1.DataModel);
 
-        _client2.DataModel.QueryLatest<Definition>().ToBlockingEnumerable().Should()
-            .BeEquivalentTo(_client1.DataModel.QueryLatest<Definition>().ToBlockingEnumerable());
+        _client2.DataModel.QueryLatest<Definition>().ToBlockingEnumerable(TestContext.Current.CancellationToken).Should()
+            .BeEquivalentTo(_client1.DataModel.QueryLatest<Definition>().ToBlockingEnumerable(TestContext.Current.CancellationToken));
     }
 }

--- a/src/SIL.Harmony.Tests/SyncTests.cs
+++ b/src/SIL.Harmony.Tests/SyncTests.cs
@@ -8,13 +8,13 @@ public class SyncTests : IAsyncLifetime
     private readonly DataModelTestBase _client1 = new();
     private readonly DataModelTestBase _client2 = new();
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _client1.InitializeAsync();
         await _client2.InitializeAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _client1.DisposeAsync();
         await _client2.DisposeAsync();


### PR DESCRIPTION
Fixes #62.

All package bumps come from running `dotnet package update` on each .csproj file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded project target to .NET 10.0
  * Updated centralized NuGet versions: EF Core to 10.x, linq2db (added extensions), and various runtime/test dependencies; added Microsoft.Testing.Platform

* **Tests**
  * Migrated testing stack to xUnit/Verify v3 and updated related test packages
  * Made test lifecycle methods return ValueTask for lighter async overhead
  * Made async test queries and file I/O cancellation-aware by passing the test cancellation token

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/harmony/pull/63)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->