### PR TITLE
Move HasCommit check inside lock in DataModel.Add

### DIFF
--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -114,8 +114,8 @@ public class DataModel : ISyncable, IAsyncDisposable
     private async Task Add(Commit commit)
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        if (await repo.HasCommit(commit.Id)) return;
         using var locked = await repo.Lock();
+        if (await repo.HasCommit(commit.Id)) return;
         repo.ClearChangeTracker();
 
         await using var transaction = repo.IsInTransaction ? null : await repo.BeginTransactionAsync();


### PR DESCRIPTION
Previously the duplicate-commit check ran before acquiring the repo lock, leaving space for a race condition.