### PR TITLE
Add DataModel.RebuildCommitHashes() for post-bootstrap rehash

### DIFF
--- a/src/SIL.Harmony.Tests/RebuildCommitHashesTests.cs
+++ b/src/SIL.Harmony.Tests/RebuildCommitHashesTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using SIL.Harmony.Core;
+
+namespace SIL.Harmony.Tests;
+
+public class RebuildCommitHashesTests : DataModelTestBase
+{
+    [Fact]
+    public async Task RebuildCommitHashes_RestoresChainAfterHashesAreCorrupted()
+    {
+        // Three commits in chain order. WriteNextChange persists them with correct hashes
+        // computed against the live chain.
+        var c1 = await WriteNextChange(SetWord(Guid.NewGuid(), "one"));
+        var c2 = await WriteNextChange(SetWord(Guid.NewGuid(), "two"));
+        var c3 = await WriteNextChange(SetWord(Guid.NewGuid(), "three"));
+
+        // Corrupt c2's hash directly. With AlwaysValidateCommits on, any further AddChange
+        // would throw — exactly the scenario RebuildCommitHashes exists to recover from
+        // (in production, the corruption comes from substituting Commit.Ids in a SQL
+        // template before the model has seen the chain).
+        var tracked = await DbContext.Commits.SingleAsync(c => c.Id == c2.Id);
+        // "BBAADD" is a valid hex string (3 bytes) — CommitBase.GenerateHash parses parentHash
+        // via Convert.FromHexString, so the corruption value still needs to look like a hash.
+        tracked.SetParentHash("BBAADD");
+        await DbContext.SaveChangesAsync();
+
+        // Sanity: validation now rejects further writes.
+        Func<Task> beforeRebuild = async () => await WriteNextChange(SetWord(Guid.NewGuid(), "four"));
+        await beforeRebuild.Should().ThrowAsync<CommitValidationException>();
+
+        // Act
+        await DataModel.RebuildCommitHashes();
+
+        // Each commit's persisted Hash must equal the hash computed from its Id + the prior
+        // commit's hash, walking from the chain root.
+        var commits = await DbContext.Commits.AsNoTracking().DefaultOrder().ToListAsync();
+        var parentHash = CommitBase.NullParentHash;
+        foreach (var commit in commits)
+        {
+            commit.Hash.Should().Be(commit.GenerateHash(parentHash));
+            commit.ParentHash.Should().Be(parentHash);
+            parentHash = commit.Hash;
+        }
+
+        // And the chain is once again accepting writes.
+        Func<Task> afterRebuild = async () => await WriteNextChange(SetWord(Guid.NewGuid(), "four"));
+        await afterRebuild.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task RebuildCommitHashes_IsNoOpOnEmptyChain()
+    {
+        // Just don't throw / don't write anything. Guards against future regressions where
+        // a callable shape (e.g. AsNoTracking + DefaultOrder().FirstAsync()) would crash on
+        // an empty table.
+        Func<Task> act = async () => await DataModel.RebuildCommitHashes();
+        await act.Should().NotThrowAsync();
+        (await DbContext.Commits.CountAsync()).Should().Be(0);
+    }
+}

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -114,8 +114,8 @@ public class DataModel : ISyncable, IAsyncDisposable
     private async Task Add(Commit commit)
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        if (await repo.HasCommit(commit.Id)) return;
         using var locked = await repo.Lock();
+        if (await repo.HasCommit(commit.Id)) return;
         repo.ClearChangeTracker();
 
         await using var transaction = repo.IsInTransaction ? null : await repo.BeginTransactionAsync();

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -237,6 +237,23 @@ public class DataModel : ISyncable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Recomputes every persisted <see cref="Commit.Hash"/> against the current Commit.Ids in chain order.
+    /// Useful when a caller has staged commits whose Ids changed after the fact (e.g. applying a
+    /// Guid-substituted SQL template) and needs the hash chain brought back in line before sync
+    /// validates it. Local-only: no replication of the rebuild — the resulting hashes must not
+    /// have been observed by any peer.
+    /// </summary>
+    public async Task RebuildCommitHashes()
+    {
+        await using var repo = await _crdtRepositoryFactory.CreateRepository();
+        using var locked = await repo.Lock();
+        repo.ClearChangeTracker();
+        await using var transaction = repo.IsInTransaction ? null : await repo.BeginTransactionAsync();
+        await repo.RebuildCommitHashes();
+        if (transaction is not null) await transaction.CommitAsync();
+    }
+
     public async Task RegenerateSnapshots()
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -428,6 +428,20 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Walks every commit in chain order and recomputes <see cref="Commit.Hash"/> / <see cref="Commit.ParentHash"/>
+    /// against the current Commit.Ids. Used when callers seed commits whose Ids change after the fact
+    /// (e.g. applying a Guid-substituted SQL template), so the persisted hashes need to be brought
+    /// back in line before any sync validates them.
+    /// </summary>
+    public async Task RebuildCommitHashes()
+    {
+        var commits = await Commits.AsTracking().DefaultOrder().ToSortedSetAsync();
+        if (commits.Count == 0) return;
+        UpdateCommitHashes(commits);
+        await _dbContext.SaveChangesAsync();
+    }
+
     public HybridDateTime? GetLatestDateTime()
     {
         return Commits


### PR DESCRIPTION
## Summary
Adds a public `DataModel.RebuildCommitHashes()` API that walks every commit in chain order and recomputes `Hash` / `ParentHash` against the current Commit.Ids. Intended for callers that have staged commits whose Ids changed after creation (e.g. applying a Guid-substituted SQL template), so the persisted hashes can be brought back in line before any sync validates them.

Local-only by contract — once any peer has observed a commit's hash, the rebuild would break sync. Takes the repo lock + transaction to match other write paths.

Also pins `Verify.EntityFramework` to the last v13 (v14+ pulls EF Core 10 abstractions, which collide with the EF 9.0.16 SQLite provider this repo stays on per the .NET 10 bump). Regenerates the `DbContextTests.VerifyModel` verified snapshot to reflect EF 9 (the previously-committed file had `ProductVersion: 10.0.7` baked in from the EF 10 churn before the rollback).

## Test plan
- [x] `RebuildCommitHashesTests.RebuildCommitHashes_RestoresChainAfterHashesAreCorrupted` — corrupts a mid-chain hash, watches AddChange reject further writes, then verifies RebuildCommitHashes restores every Hash to `GenerateHash(parentHash)` and the chain accepts writes again.
- [x] `RebuildCommitHashesTests.RebuildCommitHashes_IsNoOpOnEmptyChain` — guards against an empty-chain regression.
- [x] All 186 existing non-perf tests still pass.

Downstream caller is sillsdev/languageforge-lexbox PR #2281, where it replaces a JSON-roundtrip hack that fabricated a synthetic Commit just to trigger the same internal rehash path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public capability to rebuild and restore commit chain integrity when hash values become corrupted or inconsistent
  * Supports recovery workflows when commit identifiers have been modified

* **Bug Fixes**
  * Improved thread safety in commit operations by optimizing lock acquisition sequence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/harmony/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->