### PR TITLE
Bump EFCore.ComplexIndexes to 3.1.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,6 @@
     <PackageVersion Include="linq2db" Version="6.2.1" />
     <PackageVersion Include="linq2db.EntityFrameworkCore" Version="10.3.0" />
     <PackageVersion Include="linq2db.Extensions" Version="6.2.1" />
-    <PackageVersion Include="EFCore.ComplexIndexes" Version="2.0.5" />
+    <PackageVersion Include="EFCore.ComplexIndexes" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/src/SIL.Harmony/Db/EntityConfig/CommitEntityConfig.cs
+++ b/src/SIL.Harmony/Db/EntityConfig/CommitEntityConfig.cs
@@ -24,8 +24,8 @@ public class CommitEntityConfig : IEntityTypeConfiguration<Commit>
             });
         // Supports Harmony's DefaultOrder (ASC) directly and DefaultOrderDescending via reverse scan.
         // EF Core 10 cannot express indexes mixing ComplexProperty members + scalars (efcore#11336, targeted for 11).
-        // We use EFCore.ComplexIndexes instead. The package doesn't support column direction,
-        // but an ASC index works equivalently for reverse scans on SQLite and Postgres.
+        // We use EFCore.ComplexIndexes instead. Both Harmony sorts are uniform-direction, so a single
+        // ASC index covers both — SQLite and Postgres reverse-scan it for the descending case.
         builder.HasComplexCompositeIndex(
             c => new { c.HybridDateTime.DateTime, c.HybridDateTime.Counter, c.Id },
             indexName: "IX_Commits_DateTime_Counter_Id");


### PR DESCRIPTION
Just updating to the newest version before we merge the new dependency.

3.1.0 added per-column sort direction support, so update the comment to reflect that we don't need it (both Harmony sorts are uniform-direction) rather than that the package can't express it.