### PR TITLE
Improve exception handling and refactor unused methods in changes

### DIFF
--- a/src/SIL.Harmony/Changes/CreateChange.cs
+++ b/src/SIL.Harmony/Changes/CreateChange.cs
@@ -1,9 +1,12 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
 namespace SIL.Harmony.Changes;
 
 public abstract class CreateChange<T>(Guid entityId) : Change<T>(entityId) where T : class
 {
     public override ValueTask ApplyChange(T entity, IChangeContext context)
     {
-        throw new NotSupportedException($"type {GetType().Name} does not support ApplyChange, because it inherits from {nameof(CreateChange<T>)}, this means it must be called with a new Guid and not one from an existing entity");
+        //won't be called because it's skipped by the base class for CreateChange
+        return default;
     }
 }

--- a/src/SIL.Harmony/Changes/EditChange.cs
+++ b/src/SIL.Harmony/Changes/EditChange.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
 namespace SIL.Harmony.Changes;
 
 public abstract class EditChange<T>(Guid entityId) : Change<T>(entityId)
@@ -6,6 +8,6 @@ public abstract class EditChange<T>(Guid entityId) : Change<T>(entityId)
     public override ValueTask<T> NewEntity(Commit commit, IChangeContext context)
     {
         throw new NotSupportedException(
-            $"type {GetType().Name} does not support NewEntity, because it inherits from {nameof(EditChange<T>)}, this means it must be called with a from an existing entity, not a newly generated one");
+            $"type {GetType().ShortDisplayName()} does not support NewEntity, because it inherits from {nameof(EditChange<T>)}, this means it must be called with a from an existing entity, not a newly generated one. CommitId: {commit.Id}, EntityId: {EntityId}");
     }
 }

--- a/src/SIL.Harmony/Changes/EditChange.cs
+++ b/src/SIL.Harmony/Changes/EditChange.cs
@@ -8,6 +8,6 @@ public abstract class EditChange<T>(Guid entityId) : Change<T>(entityId)
     public override ValueTask<T> NewEntity(Commit commit, IChangeContext context)
     {
         throw new NotSupportedException(
-            $"type {GetType().ShortDisplayName()} does not support NewEntity, because it inherits from {nameof(EditChange<T>)}, this means it must be called with a from an existing entity, not a newly generated one. CommitId: {commit.Id}, EntityId: {EntityId}");
+            $"type {GetType().ShortDisplayName()} does not support NewEntity, because it inherits from {nameof(EditChange<T>)}, this means it must be called with an existing entity, not a newly generated one. CommitId: {commit.Id}, EntityId: {EntityId}");
     }
 }


### PR DESCRIPTION
Right now if an edit is called on a new entity it will throw `System.NotSupportedException: type JsonPatchChange1 does not support NewEntity...`, I fixed how the type name is generated so it will print the generic type eg `JsonPatchChange<Entry>` and also to include the commit and entity Id in the error message to aid debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal change handling and improved error messaging with additional diagnostic context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->