### PR TITLE
Enable NuGet.org publishing

### DIFF
--- a/.github/workflows/nuget-ci-cd.yml
+++ b/.github/workflows/nuget-ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Pack
         shell: bash
         run: |
-          dotnet pack --include-symbols /p:PackageVersion="$PACKAGE_VERSION" /p:AssemblyVersion="$ASSEMBLY_VERSION" /p:FileVersion="$FILE_VERSION"
+          dotnet pack /p:PackageVersion="$PACKAGE_VERSION" /p:AssemblyVersion="$ASSEMBLY_VERSION" /p:FileVersion="$FILE_VERSION"
 
       - name: Upload packages to build artifacts
         uses: actions/upload-artifact@v4
@@ -48,21 +48,27 @@ jobs:
           name: nuget-packages
           path: src/artifacts/package/release/*nupkg
 
-      # Not using the GitHub package registry right now, since it doesn't allow anonymous access so it's a hassle to use
-
-      # - name: Publish package to GitHub
-      #   if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads'))
-      #   shell: bash
-      #   run: |
-      #     dotnet nuget push "src/artifacts/package/release/*.symbols.nupkg" -s https://nuget.pkg.github.com/sillsdev/index.json -k "$NUGET_API_KEY" --skip-duplicate
-      #   env:
-      #     NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Publish package to NuGet.org
-      #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      #   shell: bash
-      #   run: |
-      #     echo Would run the following:
-      #     echo dotnet nuget push "src/artifacts/package/release/*nupkg" --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
-      #   env:
-      #     NUGET_API_KEY: ${{ secrets.SILLSDEV_PUBLISH_NUGET_ORG }}
+      - name: Publish package to NuGet.org
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for pkg in src/artifacts/package/release/*.nupkg; do
+            case "$pkg" in
+              *.symbols.nupkg|*.snupkg) continue ;;
+            esac
+            echo "Publishing $pkg"
+            dotnet nuget push "$pkg" \
+              --skip-duplicate \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json
+          done
+          for sym in src/artifacts/package/release/*.snupkg; do
+            echo "Publishing symbols $sym"
+            dotnet nuget push "$sym" \
+              --skip-duplicate \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json
+          done
+        env:
+          NUGET_API_KEY: ${{ secrets.SILLSDEV_PUBLISH_NUGET_ORG }}

--- a/.github/workflows/nuget-ci-cd.yml
+++ b/.github/workflows/nuget-ci-cd.yml
@@ -53,7 +53,19 @@ jobs:
         shell: bash
         run: |
           shopt -s nullglob
-          for pkg in src/artifacts/package/release/*.nupkg; do
+          packages=(src/artifacts/package/release/*.nupkg)
+          symbols=(src/artifacts/package/release/*.snupkg)
+
+          if ((${`#packages`[@]} == 0)); then
+            echo "No NuGet packages were produced." >&2
+            exit 1
+          fi
+          if ((${`#symbols`[@]} == 0)); then
+            echo "No symbol packages were produced." >&2
+            exit 1
+          fi
+
+          for pkg in "${packages[@]}"; do
             case "$pkg" in
               *.symbols.nupkg|*.snupkg) continue ;;
             esac
@@ -63,7 +75,7 @@ jobs:
               --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json
           done
-          for sym in src/artifacts/package/release/*.snupkg; do
+          for sym in "${symbols[@]}"; do
             echo "Publishing symbols $sym"
             dotnet nuget push "$sym" \
               --skip-duplicate \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # harmony
 
+[![NuGet version](https://img.shields.io/nuget/v/SIL.Harmony.svg?style=flat-square)](https://www.nuget.org/packages/SIL.Harmony/)
+
 A CRDT application library for C#, use it to build offline first applications.
 
 ## Install

--- a/harmony.sln
+++ b/harmony.sln
@@ -18,6 +18,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{321635F9-11D9-4B45-A2F8-F3B70E9A4196}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
 		src\.editorconfig = src\.editorconfig
 	EndProjectSection
 EndProject

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,19 @@
+<Project>
+    <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+        <Authors>SIL Global</Authors>
+        <Company>SIL Global</Company>
+        <Copyright>Copyright © SIL Global</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/sillsdev/harmony</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/sillsdev/harmony</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageTags>CRDT;offline-first;Entity Framework Core;synchronization;collaboration</PackageTags>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(IsPackable)' == 'true'">
+        <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+</Project>

--- a/src/SIL.Harmony.Core/SIL.Harmony.Core.csproj
+++ b/src/SIL.Harmony.Core/SIL.Harmony.Core.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <RootNamespace>SIL.Harmony.Core</RootNamespace>
         <IsPackable>true</IsPackable>
+        <Description>Core types and interfaces for the Harmony CRDT library.</Description>
     </PropertyGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="SIL.Harmony"/>

--- a/src/SIL.Harmony.Linq2db/SIL.Harmony.Linq2db.csproj
+++ b/src/SIL.Harmony.Linq2db/SIL.Harmony.Linq2db.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <RootNamespace>SIL.Harmony.Linq2db</RootNamespace>
         <IsPackable>true</IsPackable>
+        <Description>linq2db integration for the Harmony CRDT library.</Description>
+        <PackageTags>$(PackageTags);linq2db</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SIL.Harmony/SIL.Harmony.csproj
+++ b/src/SIL.Harmony/SIL.Harmony.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <RootNamespace>SIL.Harmony</RootNamespace>
         <IsPackable>true</IsPackable>
+        <Description>CRDT application library for building offline-first apps with Entity Framework Core.</Description>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Should allow us to get away from submodules and use package references instead.

Publish RC builds on main merges and stable releases on version tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated package publishing to NuGet.org for releases on the main branch and version tags.
  * Added package metadata including descriptions and tags across library packages.

* **Documentation**
  * Added NuGet version badge to README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->