### PR TITLE
Add synced app-defined metadata for remote resources

### DIFF
--- a/src/SIL.Harmony.Core/IRemoteResourceService.cs
+++ b/src/SIL.Harmony.Core/IRemoteResourceService.cs
@@ -5,7 +5,7 @@
 /// the remote Id is opaque to the CRDT lib and could be a URL or some other identifier provided by the backend
 /// the local path returned for the application code to use as required, it could be a URL if needed also.
 /// </summary>
-public interface IRemoteResourceService
+public interface IRemoteResourceService<TMetadata> where TMetadata : class
 {
     /// <summary>
     /// instructs application code to download a resource from the remote server
@@ -22,8 +22,8 @@ public interface IRemoteResourceService
     /// <param name="resourceId">id of the resource in the CRDT</param>
     /// <param name="localPath">full path to the resource on the local machine</param>
     /// <returns>an upload result with the remote id, the id will be stored and transmitted to other clients so they can also download the resource</returns>
-    Task<UploadResult> UploadResource(Guid resourceId, string localPath);
+    Task<UploadResult<TMetadata>> UploadResource(Guid resourceId, string localPath);
 }
 
 public record DownloadResult(string LocalPath);
-public record UploadResult(string RemoteId);
+public record UploadResult<TMetadata>(string RemoteId, TMetadata? Metadata = null) where TMetadata : class;

--- a/src/SIL.Harmony.Core/IRemoteResourceService.cs
+++ b/src/SIL.Harmony.Core/IRemoteResourceService.cs
@@ -22,7 +22,7 @@ public interface IRemoteResourceService<TMetadata> where TMetadata : class
     /// <param name="resourceId">id of the resource in the CRDT</param>
     /// <param name="localPath">full path to the resource on the local machine</param>
     /// <returns>an upload result with the remote id, the id will be stored and transmitted to other clients so they can also download the resource</returns>
-    Task<UploadResult<TMetadata>> UploadResource(Guid resourceId, string localPath);
+    Task<UploadResult<TMetadata>> UploadResource(Guid resourceId, string localPath, TMetadata? metadata = null);
 }
 
 public record DownloadResult(string LocalPath);

--- a/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
+++ b/src/SIL.Harmony.Sample/CrdtSampleKernel.cs
@@ -36,7 +36,6 @@ public static class CrdtSampleKernel
         services.AddCrdtData<SampleDbContext>(config =>
         {
             config.EnableProjectedTables = true;
-            config.AddRemoteResourceEntity();
             config.ChangeTypeListBuilder
                 .Add<NewWordChange>()
                 .Add<NewDefinitionChange>()
@@ -84,6 +83,7 @@ public static class CrdtSampleKernel
                     builder.HasIndex(wt => new { wt.WordId, wt.TagId }).IsUnique();
                 });
         });
+        services.AddCrdtRemoteResources<MediaMetadata>();
         return services;
     }
 }

--- a/src/SIL.Harmony.Sample/MediaMetadata.cs
+++ b/src/SIL.Harmony.Sample/MediaMetadata.cs
@@ -1,0 +1,3 @@
+namespace SIL.Harmony.Sample;
+
+public record MediaMetadata(string FileName, string MimeType, long SizeBytes);

--- a/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
+++ b/src/SIL.Harmony.Tests/DbContextTests.VerifyModel.verified.txt
@@ -93,16 +93,19 @@
       Relational:TableName: LocalResource
       Relational:ViewName: 
       Relational:ViewSchema: 
-  EntityType: RemoteResource
+  EntityType: RemoteResource<MediaMetadata>
     Properties: 
       Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
       DeletedAt (DateTimeOffset?)
+      Metadata (MediaMetadata)
+        Annotations: 
+          Relational:ColumnType: jsonb
       RemoteId (string)
       SnapshotId (no field, Guid?) Shadow FK Index
     Keys: 
       Id PK
     Foreign keys: 
-      RemoteResource {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
+      RemoteResource<MediaMetadata> {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
     Indexes: 
       SnapshotId Unique
     Annotations: 

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
@@ -63,6 +63,32 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
     }
 
     [Fact]
+    public async Task UploadPendingResource_IncludesMetadata()
+    {
+        var metadata = SampleMetadata("pending.mp4");
+        var localFile = CreateFile("video data");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: null);
+        _remoteServiceMock.SetUploadMetadata(localFile, SampleMetadata("FromUpload.mp4"));
+        await _resourceService.UploadPendingResource(resource.Id, _localClientId, _remoteServiceMock);
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.Metadata.Should().BeEquivalentTo(SampleMetadata("FromUpload.mp4"));
+    }
+
+    [Fact]
+    public async Task UploadPendingResources_IncludesMetadata()
+    {
+        var metadata = SampleMetadata("pending.mp4");
+        var localFile = CreateFile("video data");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: null);
+        _remoteServiceMock.SetUploadMetadata(localFile, SampleMetadata("FromUpload.mp4"));
+        await _resourceService.UploadPendingResources(_localClientId, _remoteServiceMock);
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.Metadata.Should().BeEquivalentTo(SampleMetadata("FromUpload.mp4"));
+    }
+
+    [Fact]
     public async Task AllResources_IncludesMetadata()
     {
         var metadata = SampleMetadata();

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
@@ -22,7 +22,7 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         new(fileName, "image/jpeg", 102400);
 
     [Fact]
-    public async Task CreateWithUpload_IncludesMetadata()
+    public async Task CreateWithUpload_UsesPassedMetadataWhenUploadReturnsNone()
     {
         var metadata = SampleMetadata();
         var localFile = CreateFile("image data");
@@ -32,6 +32,22 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
         stored!.Metadata.Should().BeEquivalentTo(metadata);
         (await _resourceService.GetResource(resource.Id))!.Metadata.Should().BeEquivalentTo(metadata);
+    }
+
+    [Fact]
+    public async Task CreateWithUpload_UploadMetadataOverridesPassedMetadata()
+    {
+        var passedMetadata = SampleMetadata("passed.jpg");
+        var uploadMetadata = new MediaMetadata("from-upload.jpg", "image/png", 204800);
+        var localFile = CreateFile("image data");
+        _remoteServiceMock.SetUploadMetadata(localFile, uploadMetadata);
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, passedMetadata,
+            resourceService: _remoteServiceMock);
+        resource.Metadata.Should().BeEquivalentTo(uploadMetadata);
+        resource.Metadata.Should().NotBeEquivalentTo(passedMetadata);
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.Metadata.Should().BeEquivalentTo(uploadMetadata);
+        (await _resourceService.GetResource(resource.Id))!.Metadata.Should().BeEquivalentTo(uploadMetadata);
     }
 
     [Fact]

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
@@ -89,6 +89,21 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
     }
 
     [Fact]
+    public async Task UploadPendingResources_PreservesMetadataWhenUploadReturnsNone()
+    {
+        var metadata = SampleMetadata("pending.mp4");
+        var localFile = CreateFile("video data");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: null);
+
+        await _resourceService.UploadPendingResources(_localClientId, new NullMetadataRemoteService());
+
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.RemoteId.Should().NotBeNull();
+        stored.Metadata.Should().BeEquivalentTo(metadata);
+    }
+
+    [Fact]
     public async Task AllResources_IncludesMetadata()
     {
         var metadata = SampleMetadata();
@@ -124,6 +139,24 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resourceId);
         stored!.Metadata.Should().BeNull();
         stored.RemoteId.Should().Be(remoteId);
+    }
+
+    private sealed class NullMetadataRemoteService : IRemoteResourceService<MediaMetadata>
+    {
+        private static readonly string RemotePath = Directory.CreateTempSubdirectory("NullMetadataRemoteService").FullName;
+
+        public Task<DownloadResult> DownloadResource(string remoteId, string localResourceCachePath)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<UploadResult<MediaMetadata>> UploadResource(Guid resourceId, string localPath,
+            MediaMetadata? metadata = null)
+        {
+            var remoteId = Path.Combine(RemotePath, $"{Guid.NewGuid():N}-{Path.GetFileName(localPath)}");
+            File.Copy(localPath, remoteId);
+            return Task.FromResult(new UploadResult<MediaMetadata>(remoteId));
+        }
     }
 }
 

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using SIL.Harmony.Resource;
+using SIL.Harmony.Sample;
+namespace SIL.Harmony.Tests.ResourceTests;
+public class RemoteResourcesMetadataTests : DataModelTestBase
+{
+    private RemoteServiceMock _remoteServiceMock = new();
+    private ResourceService<MediaMetadata> _resourceService =>
+        _services.GetRequiredService<ResourceService<MediaMetadata>>();
+    private string CreateFile(string contents, [CallerMemberName] string fileName = "")
+    {
+        var filePath = Path.GetFullPath(fileName + ".txt");
+        File.WriteAllText(filePath, contents);
+        return filePath;
+    }
+    private static MediaMetadata SampleMetadata(string fileName = "photo.jpg") =>
+        new(fileName, "image/jpeg", 102400);
+    [Fact]
+    public async Task CreateWithUpload_IncludesMetadata()
+    {
+        var metadata = SampleMetadata();
+        var localFile = CreateFile("image data");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: _remoteServiceMock);
+        resource.Metadata.Should().BeEquivalentTo(metadata);
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.Metadata.Should().BeEquivalentTo(metadata);
+        (await _resourceService.GetResource(resource.Id))!.Metadata.Should().BeEquivalentTo(metadata);
+    }
+    [Fact]
+    public async Task CreatePendingUpload_IncludesMetadata()
+    {
+        var metadata = SampleMetadata("pending.mp4");
+        var localFile = CreateFile("video data");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: null);
+        resource.Metadata.Should().BeEquivalentTo(metadata);
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
+        stored!.Metadata.Should().BeEquivalentTo(metadata);
+    }
+    [Fact]
+    public async Task AllResources_IncludesMetadata()
+    {
+        var metadata = SampleMetadata();
+        var localFile = CreateFile("list test");
+        await _resourceService.AddLocalResource(localFile, _localClientId, metadata, resourceService: _remoteServiceMock);
+        var all = await _resourceService.AllResources();
+        all.Should().ContainSingle().Which.Metadata.Should().BeEquivalentTo(metadata);
+    }
+    [Fact]
+    public async Task SetResourceMetadata_UpdatesAndSyncs()
+    {
+        var metadata = SampleMetadata();
+        var localFile = CreateFile("sync test");
+        var resource = await _resourceService.AddLocalResource(localFile, _localClientId, metadata,
+            resourceService: _remoteServiceMock);
+        var remoteClient = ForkDatabase();
+        var updated = metadata with { FileName = "renamed.jpg" };
+        await _resourceService.SetResourceMetadata(resource.Id, _localClientId, updated);
+        await DataModel.SyncWith(remoteClient.DataModel);
+        (await _resourceService.GetResource(resource.Id))!.Metadata.Should().BeEquivalentTo(updated);
+        (await remoteClient.DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id))!.Metadata
+            .Should().BeEquivalentTo(updated);
+    }
+    [Fact]
+    public async Task CreateWithoutMetadata_DeserializesWithNullMetadata()
+    {
+        var resourceId = Guid.NewGuid();
+        var remoteId = _remoteServiceMock.CreateRemoteResource("legacy");
+        await DataModel.AddChange(_localClientId,
+            new CreateRemoteResourceChange<MediaMetadata>(resourceId, remoteId));
+        var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resourceId);
+        stored!.Metadata.Should().BeNull();
+        stored.RemoteId.Should().Be(remoteId);
+    }
+}
+

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesMetadataTests.cs
@@ -2,20 +2,25 @@
 using Microsoft.Extensions.DependencyInjection;
 using SIL.Harmony.Resource;
 using SIL.Harmony.Sample;
+
 namespace SIL.Harmony.Tests.ResourceTests;
+
 public class RemoteResourcesMetadataTests : DataModelTestBase
 {
     private RemoteServiceMock _remoteServiceMock = new();
     private ResourceService<MediaMetadata> _resourceService =>
         _services.GetRequiredService<ResourceService<MediaMetadata>>();
+
     private string CreateFile(string contents, [CallerMemberName] string fileName = "")
     {
         var filePath = Path.GetFullPath(fileName + ".txt");
         File.WriteAllText(filePath, contents);
         return filePath;
     }
+
     private static MediaMetadata SampleMetadata(string fileName = "photo.jpg") =>
         new(fileName, "image/jpeg", 102400);
+
     [Fact]
     public async Task CreateWithUpload_IncludesMetadata()
     {
@@ -28,6 +33,7 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         stored!.Metadata.Should().BeEquivalentTo(metadata);
         (await _resourceService.GetResource(resource.Id))!.Metadata.Should().BeEquivalentTo(metadata);
     }
+
     [Fact]
     public async Task CreatePendingUpload_IncludesMetadata()
     {
@@ -39,6 +45,7 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         var stored = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id);
         stored!.Metadata.Should().BeEquivalentTo(metadata);
     }
+
     [Fact]
     public async Task AllResources_IncludesMetadata()
     {
@@ -48,6 +55,7 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         var all = await _resourceService.AllResources();
         all.Should().ContainSingle().Which.Metadata.Should().BeEquivalentTo(metadata);
     }
+
     [Fact]
     public async Task SetResourceMetadata_UpdatesAndSyncs()
     {
@@ -63,6 +71,7 @@ public class RemoteResourcesMetadataTests : DataModelTestBase
         (await remoteClient.DataModel.GetLatest<RemoteResource<MediaMetadata>>(resource.Id))!.Metadata
             .Should().BeEquivalentTo(updated);
     }
+
     [Fact]
     public async Task CreateWithoutMetadata_DeserializesWithNullMetadata()
     {

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -208,6 +208,25 @@ public class RemoteResourcesTests : DataModelTestBase
     }
 
     [Fact]
+    public void HarmonyResource_ThrowsWhenLocalAndRemoteIdsDoNotMatch()
+    {
+        var localResource = new LocalResource
+        {
+            Id = Guid.NewGuid(),
+            LocalPath = "local.txt"
+        };
+        var remoteResource = new RemoteResource<MediaMetadata>
+        {
+            Id = Guid.NewGuid(),
+            RemoteId = "remote-id"
+        };
+
+        var action = () => new HarmonyResource<MediaMetadata>(localResource, remoteResource);
+
+        action.Should().Throw<ArgumentException>().WithMessage("*matching IDs*");
+    }
+
+    [Fact]
     public async Task DeleteResource_RemovesLocalResource()
     {
         // Arrange: create a local resource

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SIL.Harmony.Resource;
 using SIL.Harmony.Sample;
@@ -11,6 +12,13 @@ public class RemoteResourcesTests : DataModelTestBase
 
     private ResourceService<MediaMetadata> _resourceService =>
         _services.GetRequiredService<ResourceService<MediaMetadata>>();
+
+    private static readonly CommitMetadata AuthorMetadata = new()
+    {
+        AuthorName = "Test Author",
+        AuthorId = "author-1",
+        ClientVersion = "1.0.0"
+    };
 
     private string CreateFile(string contents, [CallerMemberName] string fileName = "")
     {
@@ -34,6 +42,14 @@ public class RemoteResourcesTests : DataModelTestBase
         //because resource service is null the file is not uploaded
         var crdtResource = await _resourceService.AddLocalResource(file, _localClientId, resourceService: null);
         return (crdtResource.Id, file);
+    }
+
+    //setup commits carry empty metadata, so matching on AuthorName isolates the commit under test
+    private async Task AssertSingleCommitHasMetadata(CommitMetadata expected)
+    {
+        var commits = await DbContext.Commits.ToArrayAsync(TestContext.Current.CancellationToken);
+        commits.Should().ContainSingle(c => c.Metadata.AuthorName == expected.AuthorName)
+            .Which.Metadata.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -237,6 +253,85 @@ public class RemoteResourcesTests : DataModelTestBase
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
         (await _resourceService.AllResources()).Should().NotContain(r => r.Id == resourceId);
         (await _resourceService.ListResourcesPendingDownload()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AddExistingRemoteResource_AttachesCommitMetadataToTheCommit()
+    {
+        var localFile = CreateFile("existing-remote");
+
+        await _resourceService.AddExistingRemoteResource(localFile,
+            _localClientId,
+            resourceId: Guid.NewGuid(),
+            remoteId: "remote-1",
+            commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task AddLocalResource_AttachesCommitMetadataToTheCommit()
+    {
+        var localFile = CreateFile("resource");
+
+        await _resourceService.AddLocalResource(localFile, _localClientId,
+            resourceService: null, commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task SetResourceMetadata_AttachesCommitMetadataToTheCommit()
+    {
+        var (resourceId, _) = await SetupLocalFile("set-metadata");
+
+        await _resourceService.SetResourceMetadata(resourceId, _localClientId,
+            new MediaMetadata("set-metadata.txt", "text/plain", 12), commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task UploadPendingResources_AttachesCommitMetadataToTheCommit()
+    {
+        await SetupLocalFile("file1", "uploadPendingResources1");
+        await SetupLocalFile("file2", "uploadPendingResources2");
+
+        await _resourceService.UploadPendingResources(_localClientId, _remoteServiceMock, commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task UploadPendingResourceById_AttachesCommitMetadataToTheCommit()
+    {
+        var (resourceId, _) = await SetupLocalFile("upload-by-id");
+
+        await _resourceService.UploadPendingResource(resourceId, _localClientId, _remoteServiceMock, commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task UploadPendingResourceByHarmonyResource_AttachesCommitMetadataToTheCommit()
+    {
+        var (resourceId, _) = await SetupLocalFile("upload-by-resource");
+        var resource = await _resourceService.GetResource(resourceId);
+        resource.Should().NotBeNull();
+
+        await _resourceService.UploadPendingResource(resource!, _localClientId, _remoteServiceMock, commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
+    }
+
+    [Fact]
+    public async Task DeleteResource_AttachesCommitMetadataToTheCommit()
+    {
+        var (resourceId, _) = await SetupLocalFile("delete-me");
+
+        await _resourceService.DeleteResource(_localClientId, resourceId, commitMetadata: AuthorMetadata);
+
+        await AssertSingleCommitHasMetadata(AuthorMetadata);
     }
 }
 

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -2,20 +2,23 @@
 using Microsoft.Extensions.DependencyInjection;
 using SIL.Harmony.Resource;
 using SIL.Harmony.Sample;
+
 namespace SIL.Harmony.Tests.ResourceTests;
+
 public class RemoteResourcesTests : DataModelTestBase
 {
     private RemoteServiceMock _remoteServiceMock = new();
-    private ResourceService<MediaMetadata> _resourceService => _services.GetRequiredService<ResourceService<MediaMetadata>>();
-    public RemoteResourcesTests()
-    {
-    }
+
+    private ResourceService<MediaMetadata> _resourceService =>
+        _services.GetRequiredService<ResourceService<MediaMetadata>>();
+
     private string CreateFile(string contents, [CallerMemberName] string fileName = "")
     {
         var filePath = Path.GetFullPath(fileName + ".txt");
         File.WriteAllText(filePath, contents);
         return filePath;
     }
+
     private async Task<(Guid resourceId, string remoteId)> SetupRemoteResource(string fileContents)
     {
         var remoteId = _remoteServiceMock.CreateRemoteResource(fileContents);
@@ -23,13 +26,16 @@ public class RemoteResourcesTests : DataModelTestBase
         await DataModel.AddChange(_localClientId, new CreateRemoteResourceChange<MediaMetadata>(resourceId, remoteId));
         return (resourceId, remoteId);
     }
-    private async Task<(Guid resourceId, string localPath)> SetupLocalFile(string contents, [CallerMemberName] string fileName = "")
+
+    private async Task<(Guid resourceId, string localPath)> SetupLocalFile(string contents,
+        [CallerMemberName] string fileName = "")
     {
         var file = CreateFile(contents, fileName);
         //because resource service is null the file is not uploaded
         var crdtResource = await _resourceService.AddLocalResource(file, _localClientId, resourceService: null);
         return (crdtResource.Id, file);
     }
+
     [Fact]
     public async Task CreatingAResourceResultsInPendingLocalResources()
     {
@@ -39,6 +45,7 @@ public class RemoteResourcesTests : DataModelTestBase
 
         pending.Should().ContainSingle().Which.LocalPath.Should().Be(file);
     }
+
     [Fact]
     public async Task ResourcesNotLocalShouldShowUpAsNotDownloaded()
     {
@@ -50,13 +57,15 @@ public class RemoteResourcesTests : DataModelTestBase
         remoteResource.RemoteId.Should().Be(remoteId);
         remoteResource.Id.Should().Be(resourceId);
     }
+
     [Fact]
     public async Task CanUploadFileToRemote()
     {
         var fileContents = "resource";
         var localFile = CreateFile(fileContents);
         //act
-        var crdtResource = await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
+        var crdtResource =
+            await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
 
         var resource = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(crdtResource.Id);
         ArgumentNullException.ThrowIfNull(resource);
@@ -65,6 +74,7 @@ public class RemoteResourcesTests : DataModelTestBase
         var pendingUpload = await _resourceService.ListResourcesPendingUpload();
         pendingUpload.Should().BeEmpty();
     }
+
     [Fact]
     public async Task IfUploadingFailsTheResourceIsStillAddedAsPendingUpload()
     {
@@ -73,7 +83,8 @@ public class RemoteResourcesTests : DataModelTestBase
         //todo setup a mock that throws an exception when uploading
         _remoteServiceMock.ThrowOnUpload(localFile);
         //act
-        var crdtResource = await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
+        var crdtResource =
+            await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
         var harmonyResource = await _resourceService.GetResource(crdtResource.Id);
         harmonyResource.Should().NotBeNull();
         harmonyResource.Id.Should().Be(crdtResource.Id);
@@ -82,6 +93,18 @@ public class RemoteResourcesTests : DataModelTestBase
         var pendingUpload = await _resourceService.ListResourcesPendingUpload();
         pendingUpload.Should().ContainSingle().Which.Id.Should().Be(crdtResource.Id);
     }
+
+    [Fact]
+    public async Task CanUploadAPendingResource()
+    {
+        var fileContents = "resource";
+        var localFile = CreateFile(fileContents);
+        var crdtResource = await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: null);
+        //act
+        await _resourceService.UploadPendingResource(crdtResource.Id, _localClientId, _remoteServiceMock);
+        _remoteServiceMock.ListRemoteFiles().Select(Path.GetFileName).Should().Contain(Path.GetFileName(localFile));
+    }
+
     [Fact]
     public async Task WillUploadMultiplePendingLocalFilesAtOnce()
     {
@@ -95,6 +118,7 @@ public class RemoteResourcesTests : DataModelTestBase
             .Should()
             .Contain(["file1.txt", "file2.txt"]);
     }
+
     [Fact]
     public async Task CanDownloadFileFromRemote()
     {
@@ -104,11 +128,13 @@ public class RemoteResourcesTests : DataModelTestBase
         var localResource = await _resourceService.DownloadResource(resourceId, _remoteServiceMock);
 
         localResource.Id.Should().Be(resourceId);
-        var actualFileContents = await File.ReadAllTextAsync(localResource.LocalPath, TestContext.Current.CancellationToken);
+        var actualFileContents =
+            await File.ReadAllTextAsync(localResource.LocalPath, TestContext.Current.CancellationToken);
         actualFileContents.Should().Be(fileContents);
         var pendingDownloads = await _resourceService.ListResourcesPendingDownload();
         pendingDownloads.Should().BeEmpty();
     }
+
     [Fact]
     public async Task CanGetALocalResourceGivenAnId()
     {
@@ -121,6 +147,7 @@ public class RemoteResourcesTests : DataModelTestBase
         localResource.Should().NotBeNull();
         localResource!.LocalPath.Should().Be(file);
     }
+
     [Fact]
     public async Task LocalResourceIsNullIfNotDownloaded()
     {
@@ -128,30 +155,33 @@ public class RemoteResourcesTests : DataModelTestBase
         var localResource = await _resourceService.GetLocalResource(resourceId);
         localResource.Should().BeNull();
     }
+
     [Fact]
     public async Task CanListAllResources()
     {
         var (localResourceId, localResourcePath) = await SetupLocalFile("localOnly", "localOnly.txt");
         var (remoteResourceId, remoteId) = await SetupRemoteResource("remoteOnly");
-        var localAndRemoteResource = await _resourceService.AddLocalResource(CreateFile("localAndRemove"), _localClientId, resourceService: _remoteServiceMock);
+        var localAndRemoteResource = await _resourceService.AddLocalResource(CreateFile("localAndRemove"),
+            _localClientId, resourceService: _remoteServiceMock);
         var crdtResources = await _resourceService.AllResources();
         crdtResources.Should().BeEquivalentTo(
-            [
-                new HarmonyResource<MediaMetadata>
-                {
-                    Id = localResourceId,
-                    LocalPath = localResourcePath,
-                    RemoteId = null
-                },
-                new HarmonyResource<MediaMetadata>
-                {
-                    Id = remoteResourceId,
-                    LocalPath = null, 
-                    RemoteId = remoteId
-                },
-                localAndRemoteResource
-            ]);
+        [
+            new HarmonyResource<MediaMetadata>
+            {
+                Id = localResourceId,
+                LocalPath = localResourcePath,
+                RemoteId = null
+            },
+            new HarmonyResource<MediaMetadata>
+            {
+                Id = remoteResourceId,
+                LocalPath = null,
+                RemoteId = remoteId
+            },
+            localAndRemoteResource
+        ]);
     }
+
     [Fact]
     public async Task CanGetAResourceGivenAnId()
     {
@@ -166,15 +196,17 @@ public class RemoteResourcesTests : DataModelTestBase
             LocalPath = localResourcePath,
             RemoteId = null
         });
-        (await _resourceService.GetResource(remoteResourceId)).Should().BeEquivalentTo(new HarmonyResource<MediaMetadata>
-        {
-            Id = remoteResourceId,
-            LocalPath = null,
-            RemoteId = remoteId
-        });
+        (await _resourceService.GetResource(remoteResourceId)).Should().BeEquivalentTo(
+            new HarmonyResource<MediaMetadata>
+            {
+                Id = remoteResourceId,
+                LocalPath = null,
+                RemoteId = remoteId
+            });
         (await _resourceService.GetResource(localAndRemoteResource.Id)).Should().BeEquivalentTo(localAndRemoteResource);
         (await _resourceService.GetResource(Guid.NewGuid())).Should().BeNull();
     }
+
     [Fact]
     public async Task DeleteResource_RemovesLocalResource()
     {
@@ -188,7 +220,9 @@ public class RemoteResourcesTests : DataModelTestBase
         (await _resourceService.GetResource(resourceId)).Should().BeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
         (await _resourceService.AllResources()).Should().NotContain(r => r.Id == resourceId);
+        (await _resourceService.ListResourcesPendingUpload()).Should().BeEmpty();
     }
+
     [Fact]
     public async Task DeleteResource_RemovesRemoteResource()
     {
@@ -202,6 +236,7 @@ public class RemoteResourcesTests : DataModelTestBase
         (await _resourceService.GetResource(resourceId)).Should().BeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
         (await _resourceService.AllResources()).Should().NotContain(r => r.Id == resourceId);
+        (await _resourceService.ListResourcesPendingDownload()).Should().BeEmpty();
     }
 }
 

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -1,33 +1,28 @@
 ﻿using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using SIL.Harmony.Resource;
-
+using SIL.Harmony.Sample;
 namespace SIL.Harmony.Tests.ResourceTests;
-
 public class RemoteResourcesTests : DataModelTestBase
 {
     private RemoteServiceMock _remoteServiceMock = new();
-    private ResourceService _resourceService => _services.GetRequiredService<ResourceService>();
-
+    private ResourceService<MediaMetadata> _resourceService => _services.GetRequiredService<ResourceService<MediaMetadata>>();
     public RemoteResourcesTests()
     {
     }
-
     private string CreateFile(string contents, [CallerMemberName] string fileName = "")
     {
         var filePath = Path.GetFullPath(fileName + ".txt");
         File.WriteAllText(filePath, contents);
         return filePath;
     }
-
     private async Task<(Guid resourceId, string remoteId)> SetupRemoteResource(string fileContents)
     {
         var remoteId = _remoteServiceMock.CreateRemoteResource(fileContents);
         var resourceId = Guid.NewGuid();
-        await DataModel.AddChange(_localClientId, new CreateRemoteResourceChange(resourceId, remoteId));
+        await DataModel.AddChange(_localClientId, new CreateRemoteResourceChange<MediaMetadata>(resourceId, remoteId));
         return (resourceId, remoteId);
     }
-
     private async Task<(Guid resourceId, string localPath)> SetupLocalFile(string contents, [CallerMemberName] string fileName = "")
     {
         var file = CreateFile(contents, fileName);
@@ -35,63 +30,50 @@ public class RemoteResourcesTests : DataModelTestBase
         var crdtResource = await _resourceService.AddLocalResource(file, _localClientId, resourceService: null);
         return (crdtResource.Id, file);
     }
-
     [Fact]
     public async Task CreatingAResourceResultsInPendingLocalResources()
     {
         var (_, file) = await SetupLocalFile("contents");
-
         //act
         var pending = await _resourceService.ListResourcesPendingUpload();
 
-
         pending.Should().ContainSingle().Which.LocalPath.Should().Be(file);
     }
-
     [Fact]
     public async Task ResourcesNotLocalShouldShowUpAsNotDownloaded()
     {
         var (resourceId, remoteId) = await SetupRemoteResource("test");
-
         //act
         var pending = await _resourceService.ListResourcesPendingDownload();
-
 
         var remoteResource = pending.Should().ContainSingle().Subject;
         remoteResource.RemoteId.Should().Be(remoteId);
         remoteResource.Id.Should().Be(resourceId);
     }
-
     [Fact]
     public async Task CanUploadFileToRemote()
     {
         var fileContents = "resource";
         var localFile = CreateFile(fileContents);
-
         //act
         var crdtResource = await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
 
-
-        var resource = await DataModel.GetLatest<RemoteResource>(crdtResource.Id);
+        var resource = await DataModel.GetLatest<RemoteResource<MediaMetadata>>(crdtResource.Id);
         ArgumentNullException.ThrowIfNull(resource);
         ArgumentNullException.ThrowIfNull(resource.RemoteId);
         _remoteServiceMock.ReadFile(resource.RemoteId).Should().Be(fileContents);
         var pendingUpload = await _resourceService.ListResourcesPendingUpload();
         pendingUpload.Should().BeEmpty();
     }
-
     [Fact]
     public async Task IfUploadingFailsTheResourceIsStillAddedAsPendingUpload()
     {
         var fileContents = "resource";
         var localFile = CreateFile(fileContents);
-
         //todo setup a mock that throws an exception when uploading
         _remoteServiceMock.ThrowOnUpload(localFile);
-        
         //act
         var crdtResource = await _resourceService.AddLocalResource(localFile, _localClientId, resourceService: _remoteServiceMock);
-
         var harmonyResource = await _resourceService.GetResource(crdtResource.Id);
         harmonyResource.Should().NotBeNull();
         harmonyResource.Id.Should().Be(crdtResource.Id);
@@ -100,32 +82,26 @@ public class RemoteResourcesTests : DataModelTestBase
         var pendingUpload = await _resourceService.ListResourcesPendingUpload();
         pendingUpload.Should().ContainSingle().Which.Id.Should().Be(crdtResource.Id);
     }
-
     [Fact]
     public async Task WillUploadMultiplePendingLocalFilesAtOnce()
     {
         await SetupLocalFile("file1", "file1");
         await SetupLocalFile("file2", "file2");
-
         //act
         await _resourceService.UploadPendingResources(_localClientId, _remoteServiceMock);
-
 
         _remoteServiceMock.ListRemoteFiles()
             .Select(Path.GetFileName)
             .Should()
             .Contain(["file1.txt", "file2.txt"]);
     }
-
     [Fact]
     public async Task CanDownloadFileFromRemote()
     {
         var fileContents = "resource";
         var (resourceId, _) = await SetupRemoteResource(fileContents);
-
         //act
         var localResource = await _resourceService.DownloadResource(resourceId, _remoteServiceMock);
-
 
         localResource.Id.Should().Be(resourceId);
         var actualFileContents = await File.ReadAllTextAsync(localResource.LocalPath, TestContext.Current.CancellationToken);
@@ -133,22 +109,18 @@ public class RemoteResourcesTests : DataModelTestBase
         var pendingDownloads = await _resourceService.ListResourcesPendingDownload();
         pendingDownloads.Should().BeEmpty();
     }
-
     [Fact]
     public async Task CanGetALocalResourceGivenAnId()
     {
         var file = CreateFile("resource");
         //because resource service is null the file is not uploaded
         var crdtResource = await _resourceService.AddLocalResource(file, _localClientId, resourceService: null);
-
         //act
         var localResource = await _resourceService.GetLocalResource(crdtResource.Id);
-
 
         localResource.Should().NotBeNull();
         localResource!.LocalPath.Should().Be(file);
     }
-
     [Fact]
     public async Task LocalResourceIsNullIfNotDownloaded()
     {
@@ -156,24 +128,22 @@ public class RemoteResourcesTests : DataModelTestBase
         var localResource = await _resourceService.GetLocalResource(resourceId);
         localResource.Should().BeNull();
     }
-
     [Fact]
     public async Task CanListAllResources()
     {
         var (localResourceId, localResourcePath) = await SetupLocalFile("localOnly", "localOnly.txt");
         var (remoteResourceId, remoteId) = await SetupRemoteResource("remoteOnly");
         var localAndRemoteResource = await _resourceService.AddLocalResource(CreateFile("localAndRemove"), _localClientId, resourceService: _remoteServiceMock);
-
         var crdtResources = await _resourceService.AllResources();
         crdtResources.Should().BeEquivalentTo(
             [
-                new HarmonyResource
+                new HarmonyResource<MediaMetadata>
                 {
                     Id = localResourceId,
                     LocalPath = localResourcePath,
                     RemoteId = null
                 },
-                new HarmonyResource
+                new HarmonyResource<MediaMetadata>
                 {
                     Id = remoteResourceId,
                     LocalPath = null, 
@@ -182,7 +152,6 @@ public class RemoteResourcesTests : DataModelTestBase
                 localAndRemoteResource
             ]);
     }
-
     [Fact]
     public async Task CanGetAResourceGivenAnId()
     {
@@ -191,14 +160,13 @@ public class RemoteResourcesTests : DataModelTestBase
         var localAndRemoteResource = await _resourceService.AddLocalResource(CreateFile("localAndRemove"),
             _localClientId,
             resourceService: _remoteServiceMock);
-        
-        (await _resourceService.GetResource(localResourceId)).Should().BeEquivalentTo(new HarmonyResource
+        (await _resourceService.GetResource(localResourceId)).Should().BeEquivalentTo(new HarmonyResource<MediaMetadata>
         {
             Id = localResourceId,
             LocalPath = localResourcePath,
             RemoteId = null
         });
-        (await _resourceService.GetResource(remoteResourceId)).Should().BeEquivalentTo(new HarmonyResource
+        (await _resourceService.GetResource(remoteResourceId)).Should().BeEquivalentTo(new HarmonyResource<MediaMetadata>
         {
             Id = remoteResourceId,
             LocalPath = null,
@@ -207,7 +175,6 @@ public class RemoteResourcesTests : DataModelTestBase
         (await _resourceService.GetResource(localAndRemoteResource.Id)).Should().BeEquivalentTo(localAndRemoteResource);
         (await _resourceService.GetResource(Guid.NewGuid())).Should().BeNull();
     }
-
     [Fact]
     public async Task DeleteResource_RemovesLocalResource()
     {
@@ -215,16 +182,13 @@ public class RemoteResourcesTests : DataModelTestBase
         var (resourceId, localPath) = await SetupLocalFile("delete-local");
         (await _resourceService.GetResource(resourceId)).Should().NotBeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().NotBeNull();
-
         // Act: delete the resource
         await _resourceService.DeleteResource(_localClientId, resourceId);
-
         // Assert: resource is gone from all APIs
         (await _resourceService.GetResource(resourceId)).Should().BeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
         (await _resourceService.AllResources()).Should().NotContain(r => r.Id == resourceId);
     }
-
     [Fact]
     public async Task DeleteResource_RemovesRemoteResource()
     {
@@ -232,13 +196,12 @@ public class RemoteResourcesTests : DataModelTestBase
         var (resourceId, remoteId) = await SetupRemoteResource("delete-remote");
         (await _resourceService.GetResource(resourceId)).Should().NotBeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
-
         // Act: delete the resource
         await _resourceService.DeleteResource(_localClientId, resourceId);
-
         // Assert: resource is gone from all APIs
         (await _resourceService.GetResource(resourceId)).Should().BeNull();
         (await _resourceService.GetLocalResource(resourceId)).Should().BeNull();
         (await _resourceService.AllResources()).Should().NotContain(r => r.Id == resourceId);
     }
 }
+

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteResourcesTests.cs
@@ -208,6 +208,23 @@ public class RemoteResourcesTests : DataModelTestBase
     }
 
     [Fact]
+    public async Task GetResource_IgnoresDeletedRemoteResourceWhenLocalResourceExists()
+    {
+        var localAndRemoteResource = await _resourceService.AddLocalResource(CreateFile("localAndRemote"),
+            _localClientId,
+            resourceService: _remoteServiceMock);
+
+        await DataModel.AddChange(_localClientId, new DeleteRemoteResourceChange<MediaMetadata>(localAndRemoteResource.Id));
+
+        (await _resourceService.GetResource(localAndRemoteResource.Id)).Should().BeEquivalentTo(new HarmonyResource<MediaMetadata>
+        {
+            Id = localAndRemoteResource.Id,
+            LocalPath = localAndRemoteResource.LocalPath,
+            RemoteId = null
+        });
+    }
+
+    [Fact]
     public void HarmonyResource_ThrowsWhenLocalAndRemoteIdsDoNotMatch()
     {
         var localResource = new LocalResource

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
@@ -31,7 +31,7 @@ public class RemoteServiceMock : IRemoteResourceService<MediaMetadata>
     
     private readonly Queue<string> _throwOnUpload = new();
 
-    public async Task<UploadResult<MediaMetadata>> UploadResource(Guid resourceId, string localPath)
+    public async Task<UploadResult<MediaMetadata>> UploadResource(Guid resourceId, string localPath, MediaMetadata? metadata = null)
     {
         await Task.Yield();//yield back to the scheduler to emulate how exceptions are thrown
         if (_throwOnUpload.TryPeek(out var throwOnUpload))
@@ -44,8 +44,8 @@ public class RemoteServiceMock : IRemoteResourceService<MediaMetadata>
         }
         var remoteId = Path.Combine(RemotePath, Path.GetFileName(localPath));
         File.Copy(localPath, remoteId);
-        _metadata.TryGetValue(localPath, out var metadata);
-        return new UploadResult<MediaMetadata>(remoteId, metadata);
+        _metadata.TryGetValue(localPath, out var mockMetadata);
+        return new UploadResult<MediaMetadata>(remoteId, mockMetadata ?? metadata);
     }
 
     public void SetUploadMetadata(string localPath, MediaMetadata metadata) =>

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
@@ -49,7 +49,7 @@ public class RemoteServiceMock : IRemoteResourceService<MediaMetadata>
     }
 
     public void SetUploadMetadata(string localPath, MediaMetadata metadata) =>
-        _metadata[Path.GetFullPath(localPath)] = metadata;
+        _metadata[localPath] = metadata;
 
     public void ThrowOnUpload(string localPath)
     {

--- a/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/RemoteServiceMock.cs
@@ -1,17 +1,22 @@
+using SIL.Harmony.Sample;
+
 namespace SIL.Harmony.Tests.ResourceTests;
 
-public class RemoteServiceMock : IRemoteResourceService
+public class RemoteServiceMock : IRemoteResourceService<MediaMetadata>
 {
     public static readonly string RemotePath = Directory.CreateTempSubdirectory("RemoteServiceMock").FullName;
+    private readonly Dictionary<string, MediaMetadata> _metadata = new();
 
     /// <summary>
     /// directly creates a remote resource
     /// </summary>
     /// <returns>the remote id</returns>
-    public string CreateRemoteResource(string contents)
+    public string CreateRemoteResource(string contents, MediaMetadata? metadata = null)
     {
         var filePath = Path.Combine(RemotePath, Guid.NewGuid().ToString("N") + ".txt");
         File.WriteAllText(filePath, contents);
+        if (metadata is not null) _metadata.Add(filePath, metadata);
+
         return filePath;
     }
 
@@ -26,7 +31,7 @@ public class RemoteServiceMock : IRemoteResourceService
     
     private readonly Queue<string> _throwOnUpload = new();
 
-    public async Task<UploadResult> UploadResource(Guid resourceId, string localPath)
+    public async Task<UploadResult<MediaMetadata>> UploadResource(Guid resourceId, string localPath)
     {
         await Task.Yield();//yield back to the scheduler to emulate how exceptions are thrown
         if (_throwOnUpload.TryPeek(out var throwOnUpload))
@@ -39,8 +44,12 @@ public class RemoteServiceMock : IRemoteResourceService
         }
         var remoteId = Path.Combine(RemotePath, Path.GetFileName(localPath));
         File.Copy(localPath, remoteId);
-        return new UploadResult(remoteId);
+        _metadata.TryGetValue(localPath, out var metadata);
+        return new UploadResult<MediaMetadata>(remoteId, metadata);
     }
+
+    public void SetUploadMetadata(string localPath, MediaMetadata metadata) =>
+        _metadata[Path.GetFullPath(localPath)] = metadata;
 
     public void ThrowOnUpload(string localPath)
     {

--- a/src/SIL.Harmony.Tests/ResourceTests/WordResourceTests.cs
+++ b/src/SIL.Harmony.Tests/ResourceTests/WordResourceTests.cs
@@ -1,23 +1,20 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using SIL.Harmony.Sample;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
-
 namespace SIL.Harmony.Tests.ResourceTests;
-
 public class WordResourceTests: DataModelTestBase
 {
     private RemoteServiceMock _remoteServiceMock = new();
-    private ResourceService _resourceService => _services.GetRequiredService<ResourceService>();
+    private ResourceService<MediaMetadata> _resourceService => _services.GetRequiredService<ResourceService<MediaMetadata>>();
     private readonly Guid _entity1Id = Guid.NewGuid();
-
     private string CreateFile(string contents, [CallerMemberName] string fileName = "")
     {
         var filePath = Path.GetFullPath(fileName + ".txt");
         File.WriteAllText(filePath, contents);
         return filePath;
     }
-
     [Fact]
     public async Task CanReferenceAResourceFromAWord()
     {
@@ -27,12 +24,10 @@ public class WordResourceTests: DataModelTestBase
         MockTimeProvider.SetNextDateTime(NextDate());
         var resource = await _resourceService.AddLocalResource(imageFile, Guid.NewGuid(), resourceService: _remoteServiceMock);
         await WriteNextChange(new AddWordImageChange(_entity1Id, resource.Id));
-
         var word = await DataModel.GetLatest<Word>(_entity1Id);
         word.Should().NotBeNull();
         word!.ImageResourceId.Should().Be(resource.Id);
-        
-        
+
         var localResource = await _resourceService.GetLocalResource(word.ImageResourceId!.Value);
         localResource.Should().NotBeNull();
         localResource!.LocalPath.Should().Be(imageFile);

--- a/src/SIL.Harmony/CrdtConfig.cs
+++ b/src/SIL.Harmony/CrdtConfig.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore;
 using SIL.Harmony.Adapters;
@@ -6,7 +6,6 @@ using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
 using SIL.Harmony.Entities;
 using SIL.Harmony.Resource;
-
 namespace SIL.Harmony;
 public delegate ValueTask BeforeSaveObjectDelegate(object obj, ObjectSnapshot snapshot);
 public class CrdtConfig
@@ -27,7 +26,6 @@ public class CrdtConfig
     public IEnumerable<Type> ObjectTypes => ObjectTypeListBuilder.AdapterProviders.SelectMany(p => p.GetRegistrations().Select(r => r.ObjectDbType));
     public JsonSerializerOptions JsonSerializerOptions => _lazyJsonSerializerOptions.Value;
     private readonly Lazy<JsonSerializerOptions> _lazyJsonSerializerOptions;
-
     public CrdtConfig()
     {
         _lazyJsonSerializerOptions = new Lazy<JsonSerializerOptions>(() => new JsonSerializerOptions(JsonSerializerDefaults.General)
@@ -35,12 +33,10 @@ public class CrdtConfig
             TypeInfoResolver = MakeJsonTypeResolver()
         });
     }
-
     public Action<JsonTypeInfo> MakeJsonTypeModifier()
     {
         return JsonTypeModifier;
     }
-
     public IJsonTypeInfoResolver MakeJsonTypeResolver()
     {
         return new DefaultJsonTypeInfoResolver
@@ -48,7 +44,6 @@ public class CrdtConfig
             Modifiers = { MakeJsonTypeModifier() }
         };
     }
-
     private void JsonTypeModifier(JsonTypeInfo typeInfo)
     {
         ChangeTypeListBuilder.Freeze();
@@ -60,7 +55,6 @@ public class CrdtConfig
                 typeInfo.PolymorphismOptions!.DerivedTypes.Add(type);
             }
         }
-
         if (ObjectTypeListBuilder.JsonTypes?.TryGetValue(typeInfo.Type, out var types) == true)
         {
             if (typeInfo.PolymorphismOptions is null) typeInfo.PolymorphismOptions = new();
@@ -70,20 +64,33 @@ public class CrdtConfig
             }
         }
     }
-
     public bool RemoteResourcesEnabled { get; private set; }
+    public Type? RemoteResourceMetadataType { get; private set; }
     public string LocalResourceCachePath { get; set; } = Path.GetFullPath("./localResourceCache");
     public string FailedSyncOutputPath { get; set; } = Path.GetFullPath("./failedSyncs");
-
-    public void AddRemoteResourceEntity(string? cachePath = null)
+    public void AddRemoteResourceEntity<TMetadata>(string? cachePath = null)
+        where TMetadata : class
     {
         RemoteResourcesEnabled = true;
+        RemoteResourceMetadataType = typeof(TMetadata);
         LocalResourceCachePath = cachePath ?? LocalResourceCachePath;
-        ObjectTypeListBuilder.DefaultAdapter().Add<RemoteResource>();
-        ChangeTypeListBuilder.Add<RemoteResourceUploadedChange>();
-        ChangeTypeListBuilder.Add<CreateRemoteResourceChange>();
-        ChangeTypeListBuilder.Add<CreateRemoteResourcePendingUploadChange>();
-        ChangeTypeListBuilder.Add<DeleteChange<RemoteResource>>();
+        ObjectTypeListBuilder.DefaultAdapter().Add<RemoteResource<TMetadata>>(builder =>
+        {
+            builder.ToTable("RemoteResource");
+            builder.Property(r => r.Metadata)
+                .HasColumnType("jsonb")
+                .HasConversion(
+                    m => JsonSerializer.Serialize(m, (JsonSerializerOptions?)null),
+                    json => string.IsNullOrEmpty(json)
+                        ? null
+                        : JsonSerializer.Deserialize<TMetadata>(json, (JsonSerializerOptions?)null)
+                );
+        });
+        ChangeTypeListBuilder.Add<RemoteResourceUploadedChange<TMetadata>>();
+        ChangeTypeListBuilder.Add<CreateRemoteResourceChange<TMetadata>>();
+        ChangeTypeListBuilder.Add<CreateRemoteResourcePendingUploadChange<TMetadata>>();
+        ChangeTypeListBuilder.Add<SetRemoteResourceMetadataChange<TMetadata>>();
+        ChangeTypeListBuilder.Add<DeleteRemoteResourceChange<TMetadata>>();
         ObjectTypeListBuilder.ModelConfigurations.Add((builder, config) =>
         {
             var entity = builder.Entity<LocalResource>();
@@ -92,11 +99,9 @@ public class CrdtConfig
         });
     }
 }
-
 public class ChangeTypeListBuilder
 {
     private bool _frozen;
-
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
@@ -104,13 +109,11 @@ public class ChangeTypeListBuilder
     {
         _frozen = true;
     }
-
     private void CheckFrozen()
     {
         if (_frozen) throw new InvalidOperationException($"{nameof(ChangeTypeListBuilder)} is frozen");
     }
     internal List<JsonDerivedType> Types { get; } = [];
-
     public ChangeTypeListBuilder Add<TDerived>() where TDerived : IChange, IPolyType
     {
         CheckFrozen();
@@ -119,11 +122,9 @@ public class ChangeTypeListBuilder
         return this;
     }
 }
-
 public class ObjectTypeListBuilder
 {
     private bool _frozen;
-
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
@@ -144,18 +145,13 @@ public class ObjectTypeListBuilder
             });
         }
     }
-
     internal void CheckFrozen()
     {
         if (_frozen) throw new InvalidOperationException($"{nameof(ObjectTypeListBuilder)} is frozen");
     }
-
     internal Dictionary<Type, List<JsonDerivedType>> JsonTypes { get; } = [];
-
     internal List<Action<ModelBuilder, CrdtConfig>> ModelConfigurations { get; } = [];
-
     internal List<IObjectAdapterProvider> AdapterProviders { get; } = [];
-
     public DefaultAdapterProvider DefaultAdapter()
     {
         CheckFrozen();
@@ -164,7 +160,6 @@ public class ObjectTypeListBuilder
         AdapterProviders.Add(adapter);
         return adapter;
     }
-    
     /// <summary>
     /// add a custom adapter for a common interface
     /// this is required as CRDT objects must express their references and have an Id property
@@ -189,14 +184,12 @@ public class ObjectTypeListBuilder
         AdapterProviders.Add(adapter);
         return adapter;
     }
-
     internal IObjectBase Adapt(object obj)
     {
         if (AdapterProviders is [{ } defaultAdapter])
         {
             return defaultAdapter.Adapt(obj);
         }
-
         foreach (var objectAdapterProvider in AdapterProviders)
         {
             if (objectAdapterProvider.CanAdapt(obj))
@@ -207,3 +200,4 @@ public class ObjectTypeListBuilder
         throw new ArgumentException($"Unable to adapt object of type {obj.GetType()}");
     }
 }
+

--- a/src/SIL.Harmony/CrdtConfig.cs
+++ b/src/SIL.Harmony/CrdtConfig.cs
@@ -6,8 +6,11 @@ using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
 using SIL.Harmony.Entities;
 using SIL.Harmony.Resource;
+
 namespace SIL.Harmony;
+
 public delegate ValueTask BeforeSaveObjectDelegate(object obj, ObjectSnapshot snapshot);
+
 public class CrdtConfig
 {
     /// <summary>
@@ -26,6 +29,7 @@ public class CrdtConfig
     public IEnumerable<Type> ObjectTypes => ObjectTypeListBuilder.AdapterProviders.SelectMany(p => p.GetRegistrations().Select(r => r.ObjectDbType));
     public JsonSerializerOptions JsonSerializerOptions => _lazyJsonSerializerOptions.Value;
     private readonly Lazy<JsonSerializerOptions> _lazyJsonSerializerOptions;
+
     public CrdtConfig()
     {
         _lazyJsonSerializerOptions = new Lazy<JsonSerializerOptions>(() => new JsonSerializerOptions(JsonSerializerDefaults.General)
@@ -33,10 +37,12 @@ public class CrdtConfig
             TypeInfoResolver = MakeJsonTypeResolver()
         });
     }
+ 
     public Action<JsonTypeInfo> MakeJsonTypeModifier()
     {
         return JsonTypeModifier;
     }
+
     public IJsonTypeInfoResolver MakeJsonTypeResolver()
     {
         return new DefaultJsonTypeInfoResolver
@@ -44,6 +50,7 @@ public class CrdtConfig
             Modifiers = { MakeJsonTypeModifier() }
         };
     }
+
     private void JsonTypeModifier(JsonTypeInfo typeInfo)
     {
         ChangeTypeListBuilder.Freeze();
@@ -55,6 +62,7 @@ public class CrdtConfig
                 typeInfo.PolymorphismOptions!.DerivedTypes.Add(type);
             }
         }
+
         if (ObjectTypeListBuilder.JsonTypes?.TryGetValue(typeInfo.Type, out var types) == true)
         {
             if (typeInfo.PolymorphismOptions is null) typeInfo.PolymorphismOptions = new();
@@ -64,6 +72,7 @@ public class CrdtConfig
             }
         }
     }
+
     public bool RemoteResourcesEnabled { get; private set; }
     public Type? RemoteResourceMetadataType { get; private set; }
     public string LocalResourceCachePath { get; set; } = Path.GetFullPath("./localResourceCache");
@@ -99,9 +108,11 @@ public class CrdtConfig
         });
     }
 }
+
 public class ChangeTypeListBuilder
 {
     private bool _frozen;
+
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
@@ -109,11 +120,13 @@ public class ChangeTypeListBuilder
     {
         _frozen = true;
     }
+
     private void CheckFrozen()
     {
         if (_frozen) throw new InvalidOperationException($"{nameof(ChangeTypeListBuilder)} is frozen");
     }
     internal List<JsonDerivedType> Types { get; } = [];
+
     public ChangeTypeListBuilder Add<TDerived>() where TDerived : IChange, IPolyType
     {
         CheckFrozen();
@@ -122,9 +135,11 @@ public class ChangeTypeListBuilder
         return this;
     }
 }
+
 public class ObjectTypeListBuilder
 {
     private bool _frozen;
+
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
@@ -145,13 +160,16 @@ public class ObjectTypeListBuilder
             });
         }
     }
+
     internal void CheckFrozen()
     {
         if (_frozen) throw new InvalidOperationException($"{nameof(ObjectTypeListBuilder)} is frozen");
     }
+
     internal Dictionary<Type, List<JsonDerivedType>> JsonTypes { get; } = [];
     internal List<Action<ModelBuilder, CrdtConfig>> ModelConfigurations { get; } = [];
     internal List<IObjectAdapterProvider> AdapterProviders { get; } = [];
+
     public DefaultAdapterProvider DefaultAdapter()
     {
         CheckFrozen();
@@ -160,6 +178,7 @@ public class ObjectTypeListBuilder
         AdapterProviders.Add(adapter);
         return adapter;
     }
+
     /// <summary>
     /// add a custom adapter for a common interface
     /// this is required as CRDT objects must express their references and have an Id property
@@ -184,12 +203,14 @@ public class ObjectTypeListBuilder
         AdapterProviders.Add(adapter);
         return adapter;
     }
+
     internal IObjectBase Adapt(object obj)
     {
         if (AdapterProviders is [{ } defaultAdapter])
         {
             return defaultAdapter.Adapt(obj);
         }
+
         foreach (var objectAdapterProvider in AdapterProviders)
         {
             if (objectAdapterProvider.CanAdapt(obj))

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -4,25 +4,38 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Db;
-
 namespace SIL.Harmony;
-
 public static class CrdtKernel
 {
     public static IServiceCollection AddCrdtDataDbFactory<TContext>(this IServiceCollection services,
         Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
-
         services.AddCrdtDataCore(configureCrdt);
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactory<TContext>>();
         return services;
     }
-
     public static IServiceCollection AddCrdtData<TContext>(this IServiceCollection services,
         Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
         services.AddCrdtDataCore(configureCrdt);
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextNoDisposeFactory<TContext>>();
+        return services;
+    }
+    public static IServiceCollection AddCrdtRemoteResources<TMetadata>(this IServiceCollection services,
+        Action<CrdtConfig>? configureCrdt = null, string? cachePath = null)
+        where TMetadata : class
+    {
+        services.Configure<CrdtConfig>(config =>
+        {
+            config.AddRemoteResourceEntity<TMetadata>(cachePath);
+            configureCrdt?.Invoke(config);
+        });
+        services.AddScoped<ResourceService<TMetadata>>(provider => new ResourceService<TMetadata>(
+            provider.GetRequiredService<CrdtRepositoryFactory>(),
+            provider.GetRequiredService<IOptions<CrdtConfig>>(),
+            provider.GetRequiredService<DataModel>(),
+            provider.GetRequiredService<ILogger<ResourceService<TMetadata>>>()
+        ));
         return services;
     }
     public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<CrdtConfig> configureCrdt)
@@ -42,16 +55,8 @@ public static class CrdtKernel
             provider.GetRequiredService<IOptions<CrdtConfig>>(),
             provider.GetRequiredService<ILogger<DataModel>>()
         ));
-        //must use factory method because ResourceService constructor is internal
-        services.AddScoped<ResourceService>(provider => new ResourceService(
-            provider.GetRequiredService<CrdtRepositoryFactory>(),
-            provider.GetRequiredService<IOptions<CrdtConfig>>(),
-            provider.GetRequiredService<DataModel>(),
-            provider.GetRequiredService<ILogger<ResourceService>>()
-        ));
         return services;
     }
-
     public static HybridDateTimeProvider NewTimeProvider(IServiceProvider serviceProvider)
     {
         //todo, if this causes issues getting the order correct, we can update the last date time after the db is created
@@ -63,5 +68,3 @@ public static class CrdtKernel
         return ActivatorUtilities.CreateInstance<HybridDateTimeProvider>(serviceProvider, hybridDateTime);
     }
 }
-
-

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Db;
+
 namespace SIL.Harmony;
+
 public static class CrdtKernel
 {
     public static IServiceCollection AddCrdtDataDbFactory<TContext>(this IServiceCollection services,
@@ -14,6 +16,7 @@ public static class CrdtKernel
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactory<TContext>>();
         return services;
     }
+
     public static IServiceCollection AddCrdtData<TContext>(this IServiceCollection services,
         Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
@@ -21,6 +24,7 @@ public static class CrdtKernel
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextNoDisposeFactory<TContext>>();
         return services;
     }
+
     public static IServiceCollection AddCrdtRemoteResources<TMetadata>(this IServiceCollection services,
         Action<CrdtConfig>? configureCrdt = null, string? cachePath = null)
         where TMetadata : class
@@ -38,6 +42,7 @@ public static class CrdtKernel
         ));
         return services;
     }
+
     public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<CrdtConfig> configureCrdt)
     {
         services.AddLogging();
@@ -57,6 +62,7 @@ public static class CrdtKernel
         ));
         return services;
     }
+
     public static HybridDateTimeProvider NewTimeProvider(IServiceProvider serviceProvider)
     {
         //todo, if this causes issues getting the order correct, we can update the last date time after the db is created

--- a/src/SIL.Harmony/Resource/CreateRemoteResourceChange.cs
+++ b/src/SIL.Harmony/Resource/CreateRemoteResourceChange.cs
@@ -1,19 +1,27 @@
-using SIL.Harmony.Changes;
+﻿using SIL.Harmony.Changes;
 using SIL.Harmony.Entities;
 
 namespace SIL.Harmony.Resource;
 
-public class CreateRemoteResourceChange(Guid entityId, string remoteId) : CreateChange<RemoteResource>(entityId), IPolyType
+public class CreateRemoteResourceChange<TMetadata>(Guid entityId, string remoteId, TMetadata? metadata = null)
+    : CreateChange<RemoteResource<TMetadata>>(entityId), IPolyType
+    where TMetadata : class
 {
     public string RemoteId { get; set; } = remoteId;
-    public override ValueTask<RemoteResource> NewEntity(Commit commit, IChangeContext context)
+    public TMetadata? Metadata { get; set; } = metadata;
+
+    public override ValueTask<RemoteResource<TMetadata>> NewEntity(Commit commit, IChangeContext context)
     {
-        return ValueTask.FromResult(new RemoteResource
+        return ValueTask.FromResult(new RemoteResource<TMetadata>
         {
             Id = EntityId,
-            RemoteId = RemoteId
+            RemoteId = RemoteId,
+            Metadata = Metadata
         });
     }
 
     public static string TypeName => "create:remote-resource";
 }
+
+
+

--- a/src/SIL.Harmony/Resource/CreateRemoteResourcePendingUpload.cs
+++ b/src/SIL.Harmony/Resource/CreateRemoteResourcePendingUpload.cs
@@ -3,14 +3,18 @@ using SIL.Harmony.Entities;
 
 namespace SIL.Harmony.Resource;
 
-public class CreateRemoteResourcePendingUploadChange(Guid entityId)
-    : CreateChange<RemoteResource>(entityId), IPolyType
+public class CreateRemoteResourcePendingUploadChange<TMetadata>(Guid entityId, TMetadata? metadata = null)
+    : CreateChange<RemoteResource<TMetadata>>(entityId), IPolyType
+    where TMetadata : class
 {
-    public override ValueTask<RemoteResource> NewEntity(Commit commit, IChangeContext context)
+    public TMetadata? Metadata { get; set; } = metadata;
+
+    public override ValueTask<RemoteResource<TMetadata>> NewEntity(Commit commit, IChangeContext context)
     {
-        return ValueTask.FromResult(new RemoteResource
+        return ValueTask.FromResult(new RemoteResource<TMetadata>
         {
-            Id = EntityId
+            Id = EntityId,
+            Metadata = Metadata
         });
     }
 

--- a/src/SIL.Harmony/Resource/DeleteRemoteResourceChange.cs
+++ b/src/SIL.Harmony/Resource/DeleteRemoteResourceChange.cs
@@ -1,0 +1,16 @@
+using SIL.Harmony.Changes;
+using SIL.Harmony.Entities;
+
+namespace SIL.Harmony.Resource;
+
+public class DeleteRemoteResourceChange<TMetadata>(Guid entityId) : EditChange<RemoteResource<TMetadata>>(entityId), IPolyType
+    where TMetadata : class
+{
+    public static string TypeName => "delete:RemoteResource";
+
+    public override ValueTask ApplyChange(RemoteResource<TMetadata> entity, IChangeContext context)
+    {
+        context.Adapt(entity).DeletedAt = context.Commit.DateTime;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/SIL.Harmony/Resource/HarmonyResource.cs
+++ b/src/SIL.Harmony/Resource/HarmonyResource.cs
@@ -4,6 +4,20 @@ namespace SIL.Harmony.Resource;
 
 public class HarmonyResource<TMetadata> where TMetadata : class
 {
+
+    public HarmonyResource()
+    {
+        
+    }
+
+    [SetsRequiredMembers]
+    public HarmonyResource(LocalResource? localResource, RemoteResource<TMetadata>? remoteResource)
+    {
+        Id = localResource?.Id ?? remoteResource?.Id ?? throw new ArgumentNullException("Either localResource or remoteResource must be provided");
+        RemoteId = remoteResource?.RemoteId;
+        LocalPath = localResource?.LocalPath;
+        Metadata = remoteResource?.Metadata;
+    }
     public required Guid Id { get; init; }
     public string? RemoteId { get; init; }
     public string? LocalPath { get; init; }

--- a/src/SIL.Harmony/Resource/HarmonyResource.cs
+++ b/src/SIL.Harmony/Resource/HarmonyResource.cs
@@ -13,6 +13,11 @@ public class HarmonyResource<TMetadata> where TMetadata : class
     [SetsRequiredMembers]
     public HarmonyResource(LocalResource? localResource, RemoteResource<TMetadata>? remoteResource)
     {
+        if (localResource is not null && remoteResource is not null && localResource.Id != remoteResource.Id)
+        {
+            throw new ArgumentException("Local and remote resources must have matching IDs.", nameof(remoteResource));
+        }
+
         Id = localResource?.Id ?? remoteResource?.Id ?? throw new ArgumentNullException("Either localResource or remoteResource must be provided");
         RemoteId = remoteResource?.RemoteId;
         LocalPath = localResource?.LocalPath;

--- a/src/SIL.Harmony/Resource/HarmonyResource.cs
+++ b/src/SIL.Harmony/Resource/HarmonyResource.cs
@@ -1,12 +1,13 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 
 namespace SIL.Harmony.Resource;
 
-public class HarmonyResource
+public class HarmonyResource<TMetadata> where TMetadata : class
 {
     public required Guid Id { get; init; }
     public string? RemoteId { get; init; }
     public string? LocalPath { get; init; }
+    public TMetadata? Metadata { get; init; }
     [MemberNotNullWhen(true, nameof(LocalPath))]
     public bool Local => !string.IsNullOrEmpty(LocalPath);
     [MemberNotNullWhen(true, nameof(RemoteId))]

--- a/src/SIL.Harmony/Resource/RemoteResource.cs
+++ b/src/SIL.Harmony/Resource/RemoteResource.cs
@@ -1,18 +1,29 @@
-﻿using SIL.Harmony.Entities;
+﻿using System.Text.Json;
+using SIL.Harmony.Entities;
 
 namespace SIL.Harmony.Resource;
 
 /// <summary>
+/// Marker type for apps that do not need synced resource metadata.
+/// </summary>
+public sealed class NoMetadata;
+
+/// <summary>
 /// represents a remote binary resource (e.g. image, video, audio, etc.)
 /// </summary>
-public class RemoteResource: IObjectBase<RemoteResource>
+public class RemoteResource<TMetadata> : IObjectBase<RemoteResource<TMetadata>>
+    where TMetadata : class
 {
+    public static string TypeName => "RemoteResource";
+
     public Guid Id { get; init; }
     public DateTimeOffset? DeletedAt { get; set; }
     /// <summary>
     /// will be null when the resource has not been uploaded yet
     /// </summary>
     public string? RemoteId { get; set; }
+    public TMetadata? Metadata { get; set; }
+
     public Guid[] GetReferences()
     {
         return [];
@@ -24,11 +35,21 @@ public class RemoteResource: IObjectBase<RemoteResource>
 
     public IObjectBase Copy()
     {
-        return new RemoteResource
+        return new RemoteResource<TMetadata>
         {
             Id = Id,
             RemoteId = RemoteId,
-            DeletedAt = DeletedAt
+            DeletedAt = DeletedAt,
+            Metadata = CloneMetadata(Metadata)
         };
     }
+
+    private static TMetadata? CloneMetadata(TMetadata? metadata)
+    {
+        if (metadata is null) return null;
+        return JsonSerializer.Deserialize<TMetadata>(JsonSerializer.Serialize(metadata));
+    }
 }
+
+
+

--- a/src/SIL.Harmony/Resource/RemoteResourceNotEnabledException.cs
+++ b/src/SIL.Harmony/Resource/RemoteResourceNotEnabledException.cs
@@ -1,4 +1,4 @@
 ﻿namespace SIL.Harmony.Resource;
 
 public class RemoteResourceNotEnabledException()
-    : Exception("remote resources were not enabled, to enable them call CrdtConfig.AddRemoteResourceEntity when adding the CRDT library");
+    : Exception("remote resources were not enabled, to enable them call AddCrdtRemoteResources<TMetadata> when adding the CRDT library");

--- a/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
+++ b/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
@@ -6,16 +6,19 @@ namespace SIL.Harmony.Resource;
 /// <summary>
 /// used when a resource is uploaded to the remote server, stores the remote url in the resource entity
 /// </summary>
-/// <param name="entityId"></param>
-/// <param name="remoteId"></param>
-public class RemoteResourceUploadedChange(Guid entityId, string remoteId) : EditChange<RemoteResource>(entityId), IPolyType
+public class RemoteResourceUploadedChange<TMetadata>(Guid entityId, string remoteId)
+    : EditChange<RemoteResource<TMetadata>>(entityId), IPolyType
+    where TMetadata : class
 {
     public string RemoteId { get; set; } = remoteId;
     public static string TypeName => "uploaded:RemoteResource";
 
-    public override ValueTask ApplyChange(RemoteResource entity, IChangeContext context)
+    public override ValueTask ApplyChange(RemoteResource<TMetadata> entity, IChangeContext context)
     {
         entity.RemoteId = RemoteId;
         return ValueTask.CompletedTask;
     }
 }
+
+
+

--- a/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
+++ b/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
@@ -17,7 +17,11 @@ public class RemoteResourceUploadedChange<TMetadata>(Guid entityId, string remot
     public override ValueTask ApplyChange(RemoteResource<TMetadata> entity, IChangeContext context)
     {
         entity.RemoteId = RemoteId;
-        entity.Metadata = Metadata;
+        if (Metadata is not null)
+        {
+            entity.Metadata = Metadata;
+        }
+
         return ValueTask.CompletedTask;
     }
 }

--- a/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
+++ b/src/SIL.Harmony/Resource/RemoteResourceUploadedChange.cs
@@ -6,16 +6,18 @@ namespace SIL.Harmony.Resource;
 /// <summary>
 /// used when a resource is uploaded to the remote server, stores the remote url in the resource entity
 /// </summary>
-public class RemoteResourceUploadedChange<TMetadata>(Guid entityId, string remoteId)
+public class RemoteResourceUploadedChange<TMetadata>(Guid entityId, string remoteId, TMetadata? metadata = null)
     : EditChange<RemoteResource<TMetadata>>(entityId), IPolyType
     where TMetadata : class
 {
     public string RemoteId { get; set; } = remoteId;
+    public TMetadata? Metadata { get; set; } = metadata;
     public static string TypeName => "uploaded:RemoteResource";
 
     public override ValueTask ApplyChange(RemoteResource<TMetadata> entity, IChangeContext context)
     {
         entity.RemoteId = RemoteId;
+        entity.Metadata = Metadata;
         return ValueTask.CompletedTask;
     }
 }

--- a/src/SIL.Harmony/Resource/SetRemoteResourceMetadataChange.cs
+++ b/src/SIL.Harmony/Resource/SetRemoteResourceMetadataChange.cs
@@ -1,0 +1,18 @@
+using SIL.Harmony.Changes;
+using SIL.Harmony.Entities;
+
+namespace SIL.Harmony.Resource;
+
+public class SetRemoteResourceMetadataChange<TMetadata>(Guid entityId, TMetadata metadata)
+    : EditChange<RemoteResource<TMetadata>>(entityId), IPolyType
+    where TMetadata : class
+{
+    public TMetadata Metadata { get; } = metadata;
+    public static string TypeName => "set:remote-resource-metadata";
+
+    public override ValueTask ApplyChange(RemoteResource<TMetadata> entity, IChangeContext context)
+    {
+        entity.Metadata = Metadata;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -49,11 +49,20 @@ public class ResourceService<TMetadata> where TMetadata : class
         await repo.AddLocalResource(localResource);
     }
 
+    /// <summary>
+    /// add and upload a local resource
+    /// </summary>
+    /// <param name="resourcePath">path to the resource on the local machine</param>
+    /// <param name="clientId">id of the client</param>
+    /// <param name="metadata">metadata for the resource, this metadata will be overridden by the remote service if returned by <see cref="IRemoteResourceService{TMetadata}.UploadResource"/></param>
+    /// <param name="id">id of the resource</param>
+    /// <param name="resourceService">service to upload the resource to the remote server</param>
+    /// <returns>the HarmonyResource created</returns>
     public async Task<HarmonyResource<TMetadata>> AddLocalResource(string resourcePath,
         Guid clientId,
         TMetadata? metadata = null,
         Guid id = default,
-        IRemoteResourceService? resourceService = null)
+        IRemoteResourceService<TMetadata>? resourceService = null)
     {
         ValidateResourcesSetup();
         var localResource = new LocalResource
@@ -62,12 +71,13 @@ public class ResourceService<TMetadata> where TMetadata : class
             LocalPath = Path.GetFullPath(resourcePath)
         };
         if (!localResource.FileExists()) throw new FileNotFoundException(localResource.LocalPath);
-        UploadResult? uploadResult = null;
+        UploadResult<TMetadata>? uploadResult = null;
         if (resourceService is not null)
         {
             try
             {
                 uploadResult = await resourceService.UploadResource(localResource.Id, localResource.LocalPath);
+                metadata = uploadResult.Metadata ?? metadata;
             }
             catch (Exception e)
             {
@@ -113,7 +123,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         return await localResource.ToArrayAsync();
     }
 
-    public async Task UploadPendingResources(Guid clientId, IRemoteResourceService remoteResourceService)
+    public async Task UploadPendingResources(Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
     {
         ValidateResourcesSetup();
         var pendingUploads = await ListResourcesPendingUpload();
@@ -135,7 +145,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         }
     }
 
-    public async Task UploadPendingResource(Guid resourceId, Guid clientId, IRemoteResourceService remoteResourceService)
+    public async Task UploadPendingResource(Guid resourceId, Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         var localResource = await repo.GetLocalResource(resourceId) ??
@@ -145,7 +155,7 @@ public class ResourceService<TMetadata> where TMetadata : class
     }
 
     public async Task UploadPendingResource(LocalResource localResource, Guid clientId,
-        IRemoteResourceService remoteResourceService)
+        IRemoteResourceService<TMetadata> remoteResourceService)
     {
         ValidateResourcesSetup();
         var uploadResult = await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
@@ -164,7 +174,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         return remoteResources;
     }
 
-    public async Task<LocalResource> DownloadResource(Guid resourceId, IRemoteResourceService remoteResourceService)
+    public async Task<LocalResource> DownloadResource(Guid resourceId, IRemoteResourceService<TMetadata> remoteResourceService)
     {
         ValidateResourcesSetup();
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
@@ -176,7 +186,7 @@ public class ResourceService<TMetadata> where TMetadata : class
     }
 
     public async Task<LocalResource> DownloadResource(RemoteResource<TMetadata> remoteResource,
-        IRemoteResourceService remoteResourceService)
+        IRemoteResourceService<TMetadata> remoteResourceService)
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         return await DownloadResourceInternal(repo, remoteResource, remoteResourceService);
@@ -184,7 +194,7 @@ public class ResourceService<TMetadata> where TMetadata : class
 
     private async Task<LocalResource> DownloadResourceInternal(CrdtRepository repo,
         RemoteResource<TMetadata> remoteResource,
-        IRemoteResourceService remoteResourceService)
+        IRemoteResourceService<TMetadata> remoteResourceService)
     {
         ValidateResourcesSetup();
         ArgumentNullException.ThrowIfNull(remoteResource.RemoteId);

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -76,7 +76,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         {
             try
             {
-                uploadResult = await resourceService.UploadResource(localResource.Id, localResource.LocalPath);
+                uploadResult = await resourceService.UploadResource(localResource.Id, localResource.LocalPath, metadata);
                 metadata = uploadResult.Metadata ?? metadata;
             }
             catch (Exception e)
@@ -113,14 +113,14 @@ public class ResourceService<TMetadata> where TMetadata : class
         await _dataModel.AddChange(clientId, new SetRemoteResourceMetadataChange<TMetadata>(resourceId, metadata));
     }
 
-    public async Task<LocalResource[]> ListResourcesPendingUpload()
+    public async Task<HarmonyResource<TMetadata>[]> ListResourcesPendingUpload()
     {
         ValidateResourcesSetup();
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>()
-            .Where(r => r.RemoteId == null).ToArrayAsync();
-        var localResource = repo.LocalResourcesByIds(remoteResources.Select(r => r.Id));
-        return await localResource.ToArrayAsync();
+            .Where(r => r.RemoteId == null && r.DeletedAt == null).ToDictionaryAsync(r => r.Id);
+        var localResource = repo.LocalResourcesByIds(remoteResources.Keys);
+        return await localResource.Select(l => new HarmonyResource<TMetadata>(l, remoteResources.GetValueOrDefault(l.Id))).ToArrayAsync();
     }
 
     public async Task UploadPendingResources(Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
@@ -131,11 +131,11 @@ public class ResourceService<TMetadata> where TMetadata : class
         var changes = new List<IChange>(pendingUploads.Length);
         try
         {
-            foreach (var localResource in pendingUploads)
+            foreach (var resource in pendingUploads)
             {
-                var uploadResult =
-                    await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
-                changes.Add(new RemoteResourceUploadedChange<TMetadata>(localResource.Id, uploadResult.RemoteId));
+                //we know that local path is not null because we filtered for resources that are not uploaded yet
+                var uploadResult = await remoteResourceService.UploadResource(resource.Id, resource.LocalPath!, resource.Metadata);
+                changes.Add(new RemoteResourceUploadedChange<TMetadata>(resource.Id, uploadResult.RemoteId, uploadResult.Metadata));
             }
         }
         finally
@@ -147,20 +147,20 @@ public class ResourceService<TMetadata> where TMetadata : class
 
     public async Task UploadPendingResource(Guid resourceId, Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
     {
-        await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        var localResource = await repo.GetLocalResource(resourceId) ??
-                            throw new ArgumentException($"unable to find local resource with id {resourceId}");
         ValidateResourcesSetup();
-        await UploadPendingResource(localResource, clientId, remoteResourceService);
+        var resource = await GetResource(resourceId) ??
+                            throw new ArgumentException($"unable to find local resource with id {resourceId}");
+        await UploadPendingResource(resource, clientId, remoteResourceService);
     }
 
-    public async Task UploadPendingResource(LocalResource localResource, Guid clientId,
+    public async Task UploadPendingResource(HarmonyResource<TMetadata> resource, Guid clientId,
         IRemoteResourceService<TMetadata> remoteResourceService)
     {
         ValidateResourcesSetup();
-        var uploadResult = await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
+        if (resource is not {Local: true, Remote: false}) throw new ArgumentException("Resource is not pending upload");
+        var uploadResult = await remoteResourceService.UploadResource(resource.Id, resource.LocalPath, resource.Metadata);
         await _dataModel.AddChange(clientId,
-            new RemoteResourceUploadedChange<TMetadata>(localResource.Id, uploadResult.RemoteId));
+            new RemoteResourceUploadedChange<TMetadata>(resource.Id, uploadResult.RemoteId, uploadResult.Metadata));
     }
 
     public async Task<RemoteResource<TMetadata>[]> ListResourcesPendingDownload()
@@ -169,7 +169,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         var localResourceIds = repo.LocalResourceIds();
         var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>()
-            .Where(r => r.RemoteId != null && !localResourceIds.Contains(r.Id))
+            .Where(r => r.RemoteId != null && !localResourceIds.Contains(r.Id) && r.DeletedAt == null)
             .ToArrayAsync();
         return remoteResources;
     }
@@ -216,31 +216,24 @@ public class ResourceService<TMetadata> where TMetadata : class
 
     public async Task<HarmonyResource<TMetadata>[]> AllResources()
     {
-        return (await AllResourcesInternal()).ToArray();
-    }
-
-    private async Task<IEnumerable<HarmonyResource<TMetadata>>> AllResourcesInternal()
-    {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>().ToArrayAsync();
+        var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>().Where(r => r.DeletedAt == null).ToArrayAsync();
         var localResources = await repo.LocalResources().ToArrayAsync();
-        return remoteResources.FullOuterJoin<RemoteResource<TMetadata>, LocalResource, Guid, HarmonyResource<TMetadata>>(
-            localResources,
-            r => r.Id,
-            l => l.Id,
-            (r, l, id) => new HarmonyResource<TMetadata>
-            {
-                Id = id,
-                RemoteId = r?.RemoteId,
-                LocalPath = l?.LocalPath,
-                Metadata = r?.Metadata
-            });
+        return remoteResources
+            .FullOuterJoin<RemoteResource<TMetadata>, LocalResource, Guid, HarmonyResource<TMetadata>>(
+                localResources,
+                r => r.Id,
+                l => l.Id,
+                (r, l, _) => new HarmonyResource<TMetadata>(l, r)).ToArray();
     }
 
     public async Task<HarmonyResource<TMetadata>?> GetResource(Guid resourceId)
     {
-        var resources = await AllResourcesInternal();
-        return resources.FirstOrDefault(r => r.Id == resourceId);
+        await using var repo = await _crdtRepositoryFactory.CreateRepository();
+        var remoteResource = await repo.GetCurrent<RemoteResource<TMetadata>>(resourceId);
+        var localResource = await repo.GetLocalResource(resourceId);
+        if (localResource is null && remoteResource is null or {DeletedAt: not null}) return null;
+        return new HarmonyResource<TMetadata>(localResource, remoteResource);
     }
 
     public async Task DeleteResource(Guid clientId, Guid resourceId)

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -232,7 +232,8 @@ public class ResourceService<TMetadata> where TMetadata : class
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         var remoteResource = await repo.GetCurrent<RemoteResource<TMetadata>>(resourceId);
         var localResource = await repo.GetLocalResource(resourceId);
-        if (localResource is null && remoteResource is null or {DeletedAt: not null}) return null;
+        if (remoteResource is {DeletedAt: not null}) remoteResource = null;
+        if (localResource is null && remoteResource is null) return null;
         return new HarmonyResource<TMetadata>(localResource, remoteResource);
     }
 

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -33,7 +33,8 @@ public class ResourceService<TMetadata> where TMetadata : class
         Guid clientId,
         Guid resourceId,
         string remoteId,
-        TMetadata? metadata = null)
+        TMetadata? metadata = null,
+        CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
         var localResource = new LocalResource
@@ -44,7 +45,8 @@ public class ResourceService<TMetadata> where TMetadata : class
         if (!localResource.FileExists()) throw new FileNotFoundException(localResource.LocalPath);
 
         await _dataModel.AddChange(clientId,
-            new CreateRemoteResourceChange<TMetadata>(localResource.Id, remoteId, metadata));
+            new CreateRemoteResourceChange<TMetadata>(localResource.Id, remoteId, metadata),
+            commitMetadata);
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.AddLocalResource(localResource);
     }
@@ -57,12 +59,14 @@ public class ResourceService<TMetadata> where TMetadata : class
     /// <param name="metadata">metadata for the resource, this metadata will be overridden by the remote service if returned by <see cref="IRemoteResourceService{TMetadata}.UploadResource"/></param>
     /// <param name="id">id of the resource</param>
     /// <param name="resourceService">service to upload the resource to the remote server</param>
+    /// <param name="commitMetadata">metadata for the commit that records this change, for example the author</param>
     /// <returns>the HarmonyResource created</returns>
     public async Task<HarmonyResource<TMetadata>> AddLocalResource(string resourcePath,
         Guid clientId,
         TMetadata? metadata = null,
         Guid id = default,
-        IRemoteResourceService<TMetadata>? resourceService = null)
+        IRemoteResourceService<TMetadata>? resourceService = null,
+        CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
         var localResource = new LocalResource
@@ -89,12 +93,14 @@ public class ResourceService<TMetadata> where TMetadata : class
         if (uploadResult is not null)
         {
             await _dataModel.AddChange(clientId,
-                new CreateRemoteResourceChange<TMetadata>(localResource.Id, uploadResult.RemoteId, metadata));
+                new CreateRemoteResourceChange<TMetadata>(localResource.Id, uploadResult.RemoteId, metadata),
+                commitMetadata);
         }
         else
         {
             await _dataModel.AddChange(clientId,
-                new CreateRemoteResourcePendingUploadChange<TMetadata>(localResource.Id, metadata));
+                new CreateRemoteResourcePendingUploadChange<TMetadata>(localResource.Id, metadata),
+                commitMetadata);
         }
 
         await _crdtRepositoryFactory.Execute(repo => repo.AddLocalResource(localResource));
@@ -107,10 +113,10 @@ public class ResourceService<TMetadata> where TMetadata : class
         };
     }
 
-    public async Task SetResourceMetadata(Guid resourceId, Guid clientId, TMetadata metadata)
+    public async Task SetResourceMetadata(Guid resourceId, Guid clientId, TMetadata metadata, CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
-        await _dataModel.AddChange(clientId, new SetRemoteResourceMetadataChange<TMetadata>(resourceId, metadata));
+        await _dataModel.AddChange(clientId, new SetRemoteResourceMetadataChange<TMetadata>(resourceId, metadata), commitMetadata);
     }
 
     public async Task<HarmonyResource<TMetadata>[]> ListResourcesPendingUpload()
@@ -123,7 +129,7 @@ public class ResourceService<TMetadata> where TMetadata : class
         return await localResource.Select(l => new HarmonyResource<TMetadata>(l, remoteResources.GetValueOrDefault(l.Id))).ToArrayAsync();
     }
 
-    public async Task UploadPendingResources(Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
+    public async Task UploadPendingResources(Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService, CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
         var pendingUploads = await ListResourcesPendingUpload();
@@ -141,26 +147,28 @@ public class ResourceService<TMetadata> where TMetadata : class
         finally
         {
             //if upload throws at any point we will at least save the changes that did get made.
-            await _dataModel.AddChanges(clientId, changes);
+            await _dataModel.AddChanges(clientId, changes, commitMetadata);
         }
     }
 
-    public async Task UploadPendingResource(Guid resourceId, Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService)
+    public async Task UploadPendingResource(Guid resourceId, Guid clientId, IRemoteResourceService<TMetadata> remoteResourceService, CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
         var resource = await GetResource(resourceId) ??
                             throw new ArgumentException($"unable to find local resource with id {resourceId}");
-        await UploadPendingResource(resource, clientId, remoteResourceService);
+        await UploadPendingResource(resource, clientId, remoteResourceService, commitMetadata);
     }
 
     public async Task UploadPendingResource(HarmonyResource<TMetadata> resource, Guid clientId,
-        IRemoteResourceService<TMetadata> remoteResourceService)
+        IRemoteResourceService<TMetadata> remoteResourceService,
+        CommitMetadata? commitMetadata = null)
     {
         ValidateResourcesSetup();
         if (resource is not {Local: true, Remote: false}) throw new ArgumentException("Resource is not pending upload");
         var uploadResult = await remoteResourceService.UploadResource(resource.Id, resource.LocalPath, resource.Metadata);
         await _dataModel.AddChange(clientId,
-            new RemoteResourceUploadedChange<TMetadata>(resource.Id, uploadResult.RemoteId, uploadResult.Metadata));
+            new RemoteResourceUploadedChange<TMetadata>(resource.Id, uploadResult.RemoteId, uploadResult.Metadata),
+            commitMetadata);
     }
 
     public async Task<RemoteResource<TMetadata>[]> ListResourcesPendingDownload()
@@ -236,9 +244,9 @@ public class ResourceService<TMetadata> where TMetadata : class
         return new HarmonyResource<TMetadata>(localResource, remoteResource);
     }
 
-    public async Task DeleteResource(Guid clientId, Guid resourceId)
+    public async Task DeleteResource(Guid clientId, Guid resourceId, CommitMetadata? commitMetadata = null)
     {
-        await _dataModel.AddChange(clientId, new DeleteRemoteResourceChange<TMetadata>(resourceId));
+        await _dataModel.AddChange(clientId, new DeleteRemoteResourceChange<TMetadata>(resourceId), commitMetadata);
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.DeleteLocalResource(resourceId);
     }

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Changes;
@@ -8,14 +8,15 @@ using SIL.Harmony.Resource;
 
 namespace SIL.Harmony;
 
-public class ResourceService
+public class ResourceService<TMetadata> where TMetadata : class
 {
     private readonly CrdtRepositoryFactory _crdtRepositoryFactory;
     private readonly IOptions<CrdtConfig> _crdtConfig;
     private readonly DataModel _dataModel;
-    private readonly ILogger<ResourceService> _logger;
+    private readonly ILogger<ResourceService<TMetadata>> _logger;
 
-    internal ResourceService(CrdtRepositoryFactory crdtRepositoryFactory, IOptions<CrdtConfig> crdtConfig, DataModel dataModel, ILogger<ResourceService> logger)
+    internal ResourceService(CrdtRepositoryFactory crdtRepositoryFactory, IOptions<CrdtConfig> crdtConfig,
+        DataModel dataModel, ILogger<ResourceService<TMetadata>> logger)
     {
         _crdtRepositoryFactory = crdtRepositoryFactory;
         _crdtConfig = crdtConfig;
@@ -30,7 +31,9 @@ public class ResourceService
 
     public async Task AddExistingRemoteResource(string resourcePath,
         Guid clientId,
-        Guid resourceId, string remoteId)
+        Guid resourceId,
+        string remoteId,
+        TMetadata? metadata = null)
     {
         ValidateResourcesSetup();
         var localResource = new LocalResource
@@ -40,13 +43,15 @@ public class ResourceService
         };
         if (!localResource.FileExists()) throw new FileNotFoundException(localResource.LocalPath);
 
-        await _dataModel.AddChange(clientId, new CreateRemoteResourceChange(localResource.Id, remoteId));
+        await _dataModel.AddChange(clientId,
+            new CreateRemoteResourceChange<TMetadata>(localResource.Id, remoteId, metadata));
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.AddLocalResource(localResource);
     }
 
-    public async Task<HarmonyResource> AddLocalResource(string resourcePath,
+    public async Task<HarmonyResource<TMetadata>> AddLocalResource(string resourcePath,
         Guid clientId,
+        TMetadata? metadata = null,
         Guid id = default,
         IRemoteResourceService? resourceService = null)
     {
@@ -62,38 +67,48 @@ public class ResourceService
         {
             try
             {
-
                 uploadResult = await resourceService.UploadResource(localResource.Id, localResource.LocalPath);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error uploading resource {resourcePath}, resource will be marked as pending upload", localResource.LocalPath);
+                _logger.LogError(e, "Error uploading resource {resourcePath}, resource will be marked as pending upload",
+                    localResource.LocalPath);
             }
         }
 
         if (uploadResult is not null)
         {
-            await _dataModel.AddChange(clientId, new CreateRemoteResourceChange(localResource.Id, uploadResult.RemoteId));
+            await _dataModel.AddChange(clientId,
+                new CreateRemoteResourceChange<TMetadata>(localResource.Id, uploadResult.RemoteId, metadata));
         }
         else
         {
-            await _dataModel.AddChange(clientId, new CreateRemoteResourcePendingUploadChange(localResource.Id));
+            await _dataModel.AddChange(clientId,
+                new CreateRemoteResourcePendingUploadChange<TMetadata>(localResource.Id, metadata));
         }
 
         await _crdtRepositoryFactory.Execute(repo => repo.AddLocalResource(localResource));
-        return new HarmonyResource
+        return new HarmonyResource<TMetadata>
         {
             Id = localResource.Id,
             RemoteId = uploadResult?.RemoteId,
-            LocalPath = localResource.LocalPath
+            LocalPath = localResource.LocalPath,
+            Metadata = metadata
         };
+    }
+
+    public async Task SetResourceMetadata(Guid resourceId, Guid clientId, TMetadata metadata)
+    {
+        ValidateResourcesSetup();
+        await _dataModel.AddChange(clientId, new SetRemoteResourceMetadataChange<TMetadata>(resourceId, metadata));
     }
 
     public async Task<LocalResource[]> ListResourcesPendingUpload()
     {
         ValidateResourcesSetup();
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        var remoteResources = await repo.GetCurrentObjects<RemoteResource>().Where(r => r.RemoteId == null).ToArrayAsync();
+        var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>()
+            .Where(r => r.RemoteId == null).ToArrayAsync();
         var localResource = repo.LocalResourcesByIds(remoteResources.Select(r => r.Id));
         return await localResource.ToArrayAsync();
     }
@@ -108,8 +123,9 @@ public class ResourceService
         {
             foreach (var localResource in pendingUploads)
             {
-                var uploadResult = await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
-                changes.Add(new RemoteResourceUploadedChange(localResource.Id, uploadResult.RemoteId));
+                var uploadResult =
+                    await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
+                changes.Add(new RemoteResourceUploadedChange<TMetadata>(localResource.Id, uploadResult.RemoteId));
             }
         }
         finally
@@ -128,19 +144,21 @@ public class ResourceService
         await UploadPendingResource(localResource, clientId, remoteResourceService);
     }
 
-    public async Task UploadPendingResource(LocalResource localResource, Guid clientId, IRemoteResourceService remoteResourceService)
+    public async Task UploadPendingResource(LocalResource localResource, Guid clientId,
+        IRemoteResourceService remoteResourceService)
     {
         ValidateResourcesSetup();
         var uploadResult = await remoteResourceService.UploadResource(localResource.Id, localResource.LocalPath);
-        await _dataModel.AddChange(clientId, new RemoteResourceUploadedChange(localResource.Id, uploadResult.RemoteId));
+        await _dataModel.AddChange(clientId,
+            new RemoteResourceUploadedChange<TMetadata>(localResource.Id, uploadResult.RemoteId));
     }
 
-    public async Task<RemoteResource[]> ListResourcesPendingDownload()
+    public async Task<RemoteResource<TMetadata>[]> ListResourcesPendingDownload()
     {
         ValidateResourcesSetup();
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         var localResourceIds = repo.LocalResourceIds();
-        var remoteResources = await repo.GetCurrentObjects<RemoteResource>()
+        var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>()
             .Where(r => r.RemoteId != null && !localResourceIds.Contains(r.Id))
             .ToArrayAsync();
         return remoteResources;
@@ -151,13 +169,13 @@ public class ResourceService
         ValidateResourcesSetup();
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         return await DownloadResourceInternal(repo,
-            await repo.GetCurrent<RemoteResource>(resourceId) ??
+            await repo.GetCurrent<RemoteResource<TMetadata>>(resourceId) ??
             throw new EntityNotFoundException("Unable to find remote resource"),
             remoteResourceService
         );
     }
 
-    public async Task<LocalResource> DownloadResource(RemoteResource remoteResource,
+    public async Task<LocalResource> DownloadResource(RemoteResource<TMetadata> remoteResource,
         IRemoteResourceService remoteResourceService)
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
@@ -165,12 +183,13 @@ public class ResourceService
     }
 
     private async Task<LocalResource> DownloadResourceInternal(CrdtRepository repo,
-        RemoteResource remoteResource,
+        RemoteResource<TMetadata> remoteResource,
         IRemoteResourceService remoteResourceService)
     {
         ValidateResourcesSetup();
         ArgumentNullException.ThrowIfNull(remoteResource.RemoteId);
-        var downloadResult = await remoteResourceService.DownloadResource(remoteResource.RemoteId, _crdtConfig.Value.LocalResourceCachePath);
+        var downloadResult = await remoteResourceService.DownloadResource(remoteResource.RemoteId,
+            _crdtConfig.Value.LocalResourceCachePath);
         var localResource = new LocalResource
         {
             Id = remoteResource.Id,
@@ -185,28 +204,30 @@ public class ResourceService
         return await _crdtRepositoryFactory.Execute(repo => repo.GetLocalResource(resourceId));
     }
 
-    public async Task<HarmonyResource[]> AllResources()
+    public async Task<HarmonyResource<TMetadata>[]> AllResources()
     {
         return (await AllResourcesInternal()).ToArray();
     }
 
-    private async Task<IEnumerable<HarmonyResource>> AllResourcesInternal()
+    private async Task<IEnumerable<HarmonyResource<TMetadata>>> AllResourcesInternal()
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        var remoteResources = await repo.GetCurrentObjects<RemoteResource>().ToArrayAsync();
+        var remoteResources = await repo.GetCurrentObjects<RemoteResource<TMetadata>>().ToArrayAsync();
         var localResources = await repo.LocalResources().ToArrayAsync();
-        return remoteResources.FullOuterJoin<RemoteResource, LocalResource, Guid, HarmonyResource>(localResources,
+        return remoteResources.FullOuterJoin<RemoteResource<TMetadata>, LocalResource, Guid, HarmonyResource<TMetadata>>(
+            localResources,
             r => r.Id,
             l => l.Id,
-            (r, l, id) => new HarmonyResource
+            (r, l, id) => new HarmonyResource<TMetadata>
             {
                 Id = id,
                 RemoteId = r?.RemoteId,
-                LocalPath = l?.LocalPath
+                LocalPath = l?.LocalPath,
+                Metadata = r?.Metadata
             });
     }
 
-    public async Task<HarmonyResource?> GetResource(Guid resourceId)
+    public async Task<HarmonyResource<TMetadata>?> GetResource(Guid resourceId)
     {
         var resources = await AllResourcesInternal();
         return resources.FirstOrDefault(r => r.Id == resourceId);
@@ -214,7 +235,7 @@ public class ResourceService
 
     public async Task DeleteResource(Guid clientId, Guid resourceId)
     {
-        await _dataModel.AddChange(clientId, new DeleteChange<RemoteResource>(resourceId));
+        await _dataModel.AddChange(clientId, new DeleteRemoteResourceChange<TMetadata>(resourceId));
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
         await repo.DeleteLocalResource(resourceId);
     }

--- a/src/SIL.Harmony/SyncHelper.cs
+++ b/src/SIL.Harmony/SyncHelper.cs
@@ -1,19 +1,16 @@
-using System.Text.Json;
-
+﻿using System.Text.Json;
 namespace SIL.Harmony;
-
 internal static class SyncHelper
 {
-    public static async Task<SyncResults> SyncWithResourceUpload(this DataModel localModel,
+    public static async Task<SyncResults> SyncWithResourceUpload<TMetadata>(this DataModel localModel,
         ISyncable remoteModel,
-        ResourceService resourceService,
+        ResourceService<TMetadata> resourceService,
         IRemoteResourceService remoteResourceService,
-        Guid localClientId)
+        Guid localClientId) where TMetadata : class
     {
         await resourceService.UploadPendingResources(localClientId, remoteResourceService);
         return await localModel.SyncWith(remoteModel);
     }
-
     /// <summary>
     /// simple sync example, each ISyncable could be over the wire or in memory
     /// prefer that remote is over the wire for the best performance, however they could both be remote
@@ -27,7 +24,6 @@ internal static class SyncHelper
     {
         if (!await localModel.ShouldSync() || !await remoteModel.ShouldSync()) return new SyncResults([], [], false);
         var localSyncState = await localModel.GetSyncState();
-
         var (missingFromLocal, remoteSyncState) = await remoteModel.GetChanges(localSyncState);
         //todo abort if local and remote heads are the same
         var (missingFromRemote, _) = await localModel.GetChanges(remoteSyncState);
@@ -37,14 +33,12 @@ internal static class SyncHelper
             missingFromLocal = Clone(missingFromLocal, serializerOptions);
             missingFromRemote = Clone(missingFromRemote, serializerOptions);
         }
-
         if (missingFromLocal.Length > 0)
             await localModel.AddRangeFromSync(missingFromLocal);
         if (missingFromRemote.Length > 0)
             await remoteModel.AddRangeFromSync(missingFromRemote);
         return new SyncResults(missingFromLocal, missingFromRemote, true);
     }
-
     internal static async Task SyncMany(ISyncable localModel, ISyncable[] remotes, JsonSerializerOptions serializerOptions)
     {
         var localSyncState = await localModel.GetSyncState();
@@ -61,7 +55,6 @@ internal static class SyncHelper
             remoteSyncStates[i] = remoteSyncState;
             await localModel.AddRangeFromSync(missingFromLocal);
         }
-
         // Now the localModel has all the changes from all remotes, so all remotes will get the changes from the localModel as well as all other remotes
         for (var i = 0; i < remotes.Length; i++)
         {
@@ -76,7 +69,6 @@ internal static class SyncHelper
             await remote.AddRangeFromSync(missingFromRemote);
         }
     }
-
     private static T Clone<T>(this T source, JsonSerializerOptions options)
     {
         ArgumentNullException.ThrowIfNull(source);
@@ -85,3 +77,4 @@ internal static class SyncHelper
         return clone ?? throw new NullReferenceException("unable to clone object type " + typeof(T));
     }
 }
+

--- a/src/SIL.Harmony/SyncHelper.cs
+++ b/src/SIL.Harmony/SyncHelper.cs
@@ -5,7 +5,7 @@ internal static class SyncHelper
     public static async Task<SyncResults> SyncWithResourceUpload<TMetadata>(this DataModel localModel,
         ISyncable remoteModel,
         ResourceService<TMetadata> resourceService,
-        IRemoteResourceService remoteResourceService,
+        IRemoteResourceService<TMetadata> remoteResourceService,
         Guid localClientId) where TMetadata : class
     {
         await resourceService.UploadPendingResources(localClientId, remoteResourceService);


### PR DESCRIPTION
Resolves #76 (though that is not the primary goal of this PR)

## Summary

- Add generic `RemoteResource<TMetadata>` with synced `Metadata` so clients can list media without downloading blobs
- Introduce `ResourceService<TMetadata>`, `HarmonyResource<TMetadata>`, and `AddCrdtRemoteResources<TMetadata>()` DI registration
- Add CRDT changes: `SetRemoteResourceMetadataChange<TMetadata>`, `DeleteRemoteResourceChange<TMetadata>` (stable `delete:RemoteResource` type name)
- Make `IRemoteResourceService<TMetadata>` generic; `UploadResult<TMetadata>` can return server-authored metadata that overrides client-passed metadata on upload
- Add `NoMetadata` marker type for apps that do not need synced metadata fields
- Sample: `MediaMetadata` record in SIL.Harmony.Sample

## Breaking changes

- `RemoteResource`, `ResourceService`, `HarmonyResource`, and `IRemoteResourceService` are now generic-only
- `CrdtConfig.AddRemoteResourceEntity()` (non-generic) removed — use `AddCrdtRemoteResources<TMetadata>()`
- `DeleteChange<RemoteResource>` replaced by `DeleteRemoteResourceChange<TMetadata>`
- `SyncWithResourceUpload` now requires `<TMetadata>` type argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote resources now support optional metadata, so uploads/downloads and resource listings can include details like file name, MIME type, and size.
  * Resource handling and sync flows now use typed metadata end-to-end (typed resource/service APIs for better compile-time safety).

* **Bug Fixes**
  * Improved metadata behavior across upload scenarios: metadata can be preserved when uploads return none, overridden when uploads provide it, and retained through pending uploads.
  * Remote/local deletion and pending-queue behavior is now consistent, with strengthened expectations around queued downloads/uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->