### PR TITLE
Add ConfigureJsonOptions and rename CrdtConfig to Harmony

### DIFF
--- a/src/SIL.Harmony.Sample/SampleDbContext.cs
+++ b/src/SIL.Harmony.Sample/SampleDbContext.cs
@@ -1,11 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 
 namespace SIL.Harmony.Sample;
 
-public class SampleDbContext(DbContextOptions<SampleDbContext> options, IOptions<CrdtConfig> crdtConfig) : DbContext(options), ICrdtDbContext
+public class SampleDbContext(DbContextOptions<SampleDbContext> options, IOptions<HarmonyConfig> crdtConfig) : DbContext(options), ICrdtDbContext
 {
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
+++ b/src/SIL.Harmony.Tests/Adapter/CustomObjectAdapterTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Adapters;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 using SIL.Harmony.Entities;
 
@@ -11,7 +12,7 @@ namespace SIL.Harmony.Tests.Adapter;
 
 public class CustomObjectAdapterTests
 {
-    public class MyDbContext(DbContextOptions<MyDbContext> options, IOptions<CrdtConfig> crdtConfig)
+    public class MyDbContext(DbContextOptions<MyDbContext> options, IOptions<HarmonyConfig> crdtConfig)
         : DbContext(options), ICrdtDbContext
     {
         public DbSet<MyClass> MyClasses { get; set; } = null!;

--- a/src/SIL.Harmony.Tests/ConfigTests.cs
+++ b/src/SIL.Harmony.Tests/ConfigTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using SIL.Harmony.Changes;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
 using SIL.Harmony.Tests.Adapter;
@@ -26,7 +28,44 @@ public class ConfigTests
         var config = new CrdtConfig();
         config.ChangeTypeListBuilder.Add<NewDefinitionChange>();
         config.ChangeTypeListBuilder.Add<SetWordTextChange>();
+        config.ChangeTypeListBuilder.Add<DeleteChange<Word>>();
         var types = config.ChangeTypes.ToArray();
-        types.Should().BeEquivalentTo([typeof(NewDefinitionChange), typeof(SetWordTextChange)]);
+        types.Should().BeEquivalentTo([
+            new RegisteredChangeType(typeof(NewDefinitionChange), nameof(NewDefinitionChange)),
+            new RegisteredChangeType(typeof(SetWordTextChange), nameof(SetWordTextChange)),
+            new RegisteredChangeType(typeof(DeleteChange<Word>), "delete:Word"),
+        ]);
+    }
+
+    [Fact]
+    public void ConfigureJsonOptions_applies_callback()
+    {
+        var config = new CrdtConfig();
+        config.ConfigureJsonOptions(o => o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
+
+        config.JsonSerializerOptions.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.CamelCase);
+    }
+
+    [Fact]
+    public void ConfigureJsonOptions_composes_multiple_callbacks()
+    {
+        var config = new CrdtConfig();
+        config.ConfigureJsonOptions(o => o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
+        config.ConfigureJsonOptions(o => o.WriteIndented = true);
+
+        config.JsonSerializerOptions.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.CamelCase);
+        config.JsonSerializerOptions.WriteIndented.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConfigureJsonOptions_throws_after_freeze()
+    {
+        var config = new CrdtConfig();
+        _ = config.JsonSerializerOptions;
+
+        var act = () => config.ConfigureJsonOptions(o => o.WriteIndented = true);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*JsonOptionsBuilder* frozen*");
     }
 }

--- a/src/SIL.Harmony.Tests/ConfigTests.cs
+++ b/src/SIL.Harmony.Tests/ConfigTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
 using SIL.Harmony.Tests.Adapter;
@@ -11,7 +12,7 @@ public class ConfigTests
     [Fact]
     public void CanGetEntityTypes()
     {
-        var config = new CrdtConfig();
+        var config = new HarmonyConfig();
         config.ObjectTypeListBuilder.DefaultAdapter()
             .Add<Word>()
             .Add<Definition>();
@@ -25,7 +26,7 @@ public class ConfigTests
     [Fact]
     public void CanGetChangeTypes()
     {
-        var config = new CrdtConfig();
+        var config = new HarmonyConfig();
         config.ChangeTypeListBuilder.Add<NewDefinitionChange>();
         config.ChangeTypeListBuilder.Add<SetWordTextChange>();
         config.ChangeTypeListBuilder.Add<DeleteChange<Word>>();
@@ -40,7 +41,7 @@ public class ConfigTests
     [Fact]
     public void ConfigureJsonOptions_applies_callback()
     {
-        var config = new CrdtConfig();
+        var config = new HarmonyConfig();
         config.ConfigureJsonOptions(o => o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
 
         config.JsonSerializerOptions.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.CamelCase);
@@ -49,7 +50,7 @@ public class ConfigTests
     [Fact]
     public void ConfigureJsonOptions_composes_multiple_callbacks()
     {
-        var config = new CrdtConfig();
+        var config = new HarmonyConfig();
         config.ConfigureJsonOptions(o => o.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
         config.ConfigureJsonOptions(o => o.WriteIndented = true);
 
@@ -60,7 +61,7 @@ public class ConfigTests
     [Fact]
     public void ConfigureJsonOptions_throws_after_freeze()
     {
-        var config = new CrdtConfig();
+        var config = new HarmonyConfig();
         _ = config.JsonSerializerOptions;
 
         var act = () => config.ConfigureJsonOptions(o => o.WriteIndented = true);

--- a/src/SIL.Harmony.Tests/DataModelTestBase.cs
+++ b/src/SIL.Harmony.Tests/DataModelTestBase.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 using SIL.Harmony.Sample;
 using SIL.Harmony.Sample.Changes;
@@ -38,7 +39,7 @@ public class DataModelTestBase : IAsyncLifetime
             {
                 builder.UseSqlite(connection, true);
             }, performanceTest)
-            .Configure<CrdtConfig>(config => config.AlwaysValidateCommits = alwaysValidate)
+            .Configure<HarmonyConfig>(config => config.AlwaysValidateCommits = alwaysValidate)
             .Replace(ServiceDescriptor.Singleton<IHybridDateTimeProvider>(MockTimeProvider));
         configure?.Invoke(serviceCollection);
         _services = serviceCollection.BuildServiceProvider();

--- a/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
+++ b/src/SIL.Harmony.Tests/PersistExtraDataTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Entities;
 
 namespace SIL.Harmony.Tests;
@@ -53,7 +54,7 @@ public class PersistExtraDataTests
     {
         _dataModelTestBase = new DataModelTestBase(configure: services =>
         {
-            services.Configure<CrdtConfig>(config =>
+            services.Configure<HarmonyConfig>(config =>
             {
                 config.ObjectTypeListBuilder.DefaultAdapter().Add<ExtraDataModel>();
                 config.ChangeTypeListBuilder.Add<CreateExtraDataModelChange>();

--- a/src/SIL.Harmony/Adapters/CustomAdapterProvider.cs
+++ b/src/SIL.Harmony/Adapters/CustomAdapterProvider.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SIL.Harmony.Config;
 using SIL.Harmony.Entities;
 using SIL.Harmony.Helpers;
 

--- a/src/SIL.Harmony/Adapters/DefaultAdapterProvider.cs
+++ b/src/SIL.Harmony/Adapters/DefaultAdapterProvider.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SIL.Harmony.Config;
 using SIL.Harmony.Entities;
 using SIL.Harmony.Helpers;
 

--- a/src/SIL.Harmony/Changes/Change.cs
+++ b/src/SIL.Harmony/Changes/Change.cs
@@ -5,7 +5,7 @@ namespace SIL.Harmony.Changes;
 
 /// <summary>
 /// Polymorphic JSON for <see cref="IChange"/> is owned by
-/// <c>PeekThenConcreteChangeConverter</c> (via <see cref="CrdtConfig"/>), not
+/// <c>PeekThenConcreteChangeConverter</c> (via <see cref="Config.HarmonyConfig"/>), not
 /// <see cref="JsonPolymorphicAttribute"/>. Unknown <c>$type</c> values become
 /// <see cref="OpaqueChange"/>.
 /// </summary>

--- a/src/SIL.Harmony/Changes/ChangeContext.cs
+++ b/src/SIL.Harmony/Changes/ChangeContext.cs
@@ -1,3 +1,4 @@
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 
 namespace SIL.Harmony.Changes;
@@ -5,9 +6,9 @@ namespace SIL.Harmony.Changes;
 internal class ChangeContext : IChangeContext
 {
     private readonly SnapshotWorker _worker;
-    private readonly CrdtConfig _crdtConfig;
+    private readonly HarmonyConfig _crdtConfig;
 
-    internal ChangeContext(Commit commit, int commitIndex, IDictionary<Guid, ObjectSnapshot> intermediateSnapshots, SnapshotWorker worker, CrdtConfig crdtConfig)
+    internal ChangeContext(Commit commit, int commitIndex, IDictionary<Guid, ObjectSnapshot> intermediateSnapshots, SnapshotWorker worker, HarmonyConfig crdtConfig)
     {
         _worker = worker;
         _crdtConfig = crdtConfig;

--- a/src/SIL.Harmony/Changes/PeekThenConcreteChangeConverter.cs
+++ b/src/SIL.Harmony/Changes/PeekThenConcreteChangeConverter.cs
@@ -7,7 +7,7 @@ namespace SIL.Harmony.Changes;
 
 /// <summary>
 /// Owns <see cref="IChange"/> discrimination. Requires <c>$type</c> as the first JSON property
-/// (matching synthetic write order from <see cref="CrdtConfig"/>).
+/// (matching synthetic write order from <see cref="Config.HarmonyConfig"/>).
 /// Known discriminators deserialize via cached concrete <see cref="JsonTypeInfo"/>;
 /// unknown → <see cref="OpaqueChange"/> preserving the raw payload.
 /// </summary>

--- a/src/SIL.Harmony/Config/ChangeTypeListBuilder.cs
+++ b/src/SIL.Harmony/Config/ChangeTypeListBuilder.cs
@@ -1,0 +1,35 @@
+using SIL.Harmony.Changes;
+using SIL.Harmony.Entities;
+
+namespace SIL.Harmony.Config;
+
+public readonly record struct RegisteredChangeType(Type Type, string Discriminator);
+
+public class ChangeTypeListBuilder
+{
+    private bool _frozen;
+
+    /// <summary>
+    /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
+    /// </summary>
+    public void Freeze()
+    {
+        _frozen = true;
+    }
+
+    private void CheckFrozen()
+    {
+        if (_frozen) throw new InvalidOperationException($"{nameof(ChangeTypeListBuilder)} is frozen");
+    }
+
+    private readonly List<RegisteredChangeType> _types = [];
+    public IReadOnlyList<RegisteredChangeType> Types => _types.AsReadOnly();
+
+    public ChangeTypeListBuilder Add<TDerived>() where TDerived : IChange, IPolyType
+    {
+        CheckFrozen();
+        if (_types.Any(t => t.Type == typeof(TDerived))) return this;
+        _types.Add(new RegisteredChangeType(typeof(TDerived), TDerived.TypeName));
+        return this;
+    }
+}

--- a/src/SIL.Harmony/Config/ChangeTypeListBuilder.cs
+++ b/src/SIL.Harmony/Config/ChangeTypeListBuilder.cs
@@ -12,7 +12,7 @@ public class ChangeTypeListBuilder
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
-    public void Freeze()
+    internal void Freeze()
     {
         _frozen = true;
     }

--- a/src/SIL.Harmony/Config/HarmonyConfig.cs
+++ b/src/SIL.Harmony/Config/HarmonyConfig.cs
@@ -1,19 +1,15 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore;
-using SIL.Harmony.Adapters;
 using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
-using SIL.Harmony.Entities;
 using SIL.Harmony.Resource;
 
-namespace SIL.Harmony;
+namespace SIL.Harmony.Config;
 
 public delegate ValueTask BeforeSaveObjectDelegate(object obj, ObjectSnapshot snapshot);
 
-public readonly record struct RegisteredChangeType(Type Type, string Discriminator);
-
-public class CrdtConfig
+public class HarmonyConfig
 {
     /// <summary>
     /// recommended to increase query performance, as getting objects can just query the table for that object.
@@ -34,7 +30,7 @@ public class CrdtConfig
     private readonly Lazy<JsonSerializerOptions> _lazyJsonSerializerOptions;
     private readonly Lazy<ChangeDiscriminatorMaps> _lazyChangeDiscriminatorMaps;
 
-    public CrdtConfig()
+    public HarmonyConfig()
     {
         _lazyChangeDiscriminatorMaps = new Lazy<ChangeDiscriminatorMaps>(BuildChangeDiscriminatorMaps);
         _lazyJsonSerializerOptions = new Lazy<JsonSerializerOptions>(CreateJsonSerializerOptions);
@@ -166,144 +162,3 @@ public class CrdtConfig
         });
     }
 }
-
-internal class JsonOptionsBuilder
-{
-    private bool _frozen;
-    private readonly List<Action<JsonSerializerOptions>> _configurations = [];
-
-    public void Configure(Action<JsonSerializerOptions> configure)
-    {
-        CheckFrozen();
-        _configurations.Add(configure);
-    }
-
-    internal void ApplyTo(JsonSerializerOptions options)
-    {
-        foreach (var configure in _configurations)
-            configure(options);
-        Freeze();
-    }
-
-    private void Freeze() => _frozen = true;
-
-    private void CheckFrozen()
-    {
-        if (_frozen) throw new InvalidOperationException($"{nameof(JsonOptionsBuilder)} is frozen");
-    }
-}
-
-public class ChangeTypeListBuilder
-{
-    private bool _frozen;
-
-    /// <summary>
-    /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
-    /// </summary>
-    public void Freeze()
-    {
-        _frozen = true;
-    }
-
-    private void CheckFrozen()
-    {
-        if (_frozen) throw new InvalidOperationException($"{nameof(ChangeTypeListBuilder)} is frozen");
-    }
-    private readonly List<RegisteredChangeType> _types = [];
-    public IReadOnlyList<RegisteredChangeType> Types => _types.AsReadOnly();
-
-    public ChangeTypeListBuilder Add<TDerived>() where TDerived : IChange, IPolyType
-    {
-        CheckFrozen();
-        if (_types.Any(t => t.Type == typeof(TDerived))) return this;
-        _types.Add(new RegisteredChangeType(typeof(TDerived), TDerived.TypeName));
-        return this;
-    }
-}
-
-public class ObjectTypeListBuilder
-{
-    private bool _frozen;
-
-    /// <summary>
-    /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
-    /// </summary>
-    public void Freeze()
-    {
-        if (_frozen) return;
-        _frozen = true;
-        foreach (var registration in AdapterProviders.SelectMany(a => a.GetRegistrations()))
-        {
-            ModelConfigurations.Add((builder, config) =>
-            {
-                if (!config.EnableProjectedTables) return;
-                var entity = registration.EntityBuilder(builder);
-                entity.HasOne(typeof(ObjectSnapshot))
-                    .WithOne()
-                    .HasForeignKey(registration.ObjectDbType, ObjectSnapshot.ShadowRefName)
-                    .OnDelete(DeleteBehavior.SetNull);
-            });
-        }
-    }
-
-    internal void CheckFrozen()
-    {
-        if (_frozen) throw new InvalidOperationException($"{nameof(ObjectTypeListBuilder)} is frozen");
-    }
-
-    internal Dictionary<Type, List<JsonDerivedType>> JsonTypes { get; } = [];
-    internal List<Action<ModelBuilder, CrdtConfig>> ModelConfigurations { get; } = [];
-    internal List<IObjectAdapterProvider> AdapterProviders { get; } = [];
-
-    public DefaultAdapterProvider DefaultAdapter()
-    {
-        CheckFrozen();
-        if (AdapterProviders.OfType<DefaultAdapterProvider>().SingleOrDefault() is { } adapter) return adapter;
-        adapter = new DefaultAdapterProvider(this);
-        AdapterProviders.Add(adapter);
-        return adapter;
-    }
-
-    /// <summary>
-    /// add a custom adapter for a common interface
-    /// this is required as CRDT objects must express their references and have an Id property
-    /// using a custom adapter allows your model to not take a dependency on Harmony
-    /// </summary>
-    /// <typeparam name="TCommonInterface">
-    /// A common interface that all objects in your application implement
-    /// which System.Text.Json will deserialize your objects to, they must support polymorphic deserialization
-    /// </typeparam>
-    /// <typeparam name="TAdapter">
-    /// This adapter will be serialized and stored in the database,
-    /// it should include the object it is adapting otherwise Harmony will not work
-    /// </typeparam>
-    /// <returns></returns>
-    /// <exception cref="InvalidOperationException">when another adapter has already been added or the config has been frozen</exception>
-    public CustomAdapterProvider<TCommonInterface, TAdapter> CustomAdapter<TCommonInterface, TAdapter>()
-        where TCommonInterface : class where TAdapter : class, ICustomAdapter<TAdapter, TCommonInterface>, IPolyType
-    {
-        CheckFrozen();
-        if (AdapterProviders.OfType<CustomAdapterProvider<TCommonInterface, TAdapter>>().SingleOrDefault() is { } adapter) return adapter;
-        adapter = new CustomAdapterProvider<TCommonInterface, TAdapter>(this);
-        AdapterProviders.Add(adapter);
-        return adapter;
-    }
-
-    internal IObjectBase Adapt(object obj)
-    {
-        if (AdapterProviders is [{ } defaultAdapter])
-        {
-            return defaultAdapter.Adapt(obj);
-        }
-
-        foreach (var objectAdapterProvider in AdapterProviders)
-        {
-            if (objectAdapterProvider.CanAdapt(obj))
-            {
-                return objectAdapterProvider.Adapt(obj);
-            }
-        }
-        throw new ArgumentException($"Unable to adapt object of type {obj.GetType()}");
-    }
-}
-

--- a/src/SIL.Harmony/Config/JsonOptionsBuilder.cs
+++ b/src/SIL.Harmony/Config/JsonOptionsBuilder.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace SIL.Harmony.Config;
+
+internal class JsonOptionsBuilder
+{
+    private bool _frozen;
+    private readonly List<Action<JsonSerializerOptions>> _configurations = [];
+
+    public void Configure(Action<JsonSerializerOptions> configure)
+    {
+        CheckFrozen();
+        _configurations.Add(configure);
+    }
+
+    internal void ApplyTo(JsonSerializerOptions options)
+    {
+        foreach (var configure in _configurations)
+            configure(options);
+        Freeze();
+    }
+
+    private void Freeze() => _frozen = true;
+
+    private void CheckFrozen()
+    {
+        if (_frozen) throw new InvalidOperationException($"{nameof(JsonOptionsBuilder)} is frozen");
+    }
+}

--- a/src/SIL.Harmony/Config/ObjectTypeListBuilder.cs
+++ b/src/SIL.Harmony/Config/ObjectTypeListBuilder.cs
@@ -1,0 +1,93 @@
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.EntityFrameworkCore;
+using SIL.Harmony.Adapters;
+using SIL.Harmony.Db;
+using SIL.Harmony.Entities;
+
+namespace SIL.Harmony.Config;
+
+public class ObjectTypeListBuilder
+{
+    private bool _frozen;
+
+    /// <summary>
+    /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
+    /// </summary>
+    public void Freeze()
+    {
+        if (_frozen) return;
+        _frozen = true;
+        foreach (var registration in AdapterProviders.SelectMany(a => a.GetRegistrations()))
+        {
+            ModelConfigurations.Add((builder, config) =>
+            {
+                if (!config.EnableProjectedTables) return;
+                var entity = registration.EntityBuilder(builder);
+                entity.HasOne(typeof(ObjectSnapshot))
+                    .WithOne()
+                    .HasForeignKey(registration.ObjectDbType, ObjectSnapshot.ShadowRefName)
+                    .OnDelete(DeleteBehavior.SetNull);
+            });
+        }
+    }
+
+    internal void CheckFrozen()
+    {
+        if (_frozen) throw new InvalidOperationException($"{nameof(ObjectTypeListBuilder)} is frozen");
+    }
+
+    internal Dictionary<Type, List<JsonDerivedType>> JsonTypes { get; } = [];
+    internal List<Action<ModelBuilder, HarmonyConfig>> ModelConfigurations { get; } = [];
+    internal List<IObjectAdapterProvider> AdapterProviders { get; } = [];
+
+    public DefaultAdapterProvider DefaultAdapter()
+    {
+        CheckFrozen();
+        if (AdapterProviders.OfType<DefaultAdapterProvider>().SingleOrDefault() is { } adapter) return adapter;
+        adapter = new DefaultAdapterProvider(this);
+        AdapterProviders.Add(adapter);
+        return adapter;
+    }
+
+    /// <summary>
+    /// add a custom adapter for a common interface
+    /// this is required as CRDT objects must express their references and have an Id property
+    /// using a custom adapter allows your model to not take a dependency on Harmony
+    /// </summary>
+    /// <typeparam name="TCommonInterface">
+    /// A common interface that all objects in your application implement
+    /// which System.Text.Json will deserialize your objects to, they must support polymorphic deserialization
+    /// </typeparam>
+    /// <typeparam name="TAdapter">
+    /// This adapter will be serialized and stored in the database,
+    /// it should include the object it is adapting otherwise Harmony will not work
+    /// </typeparam>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">when another adapter has already been added or the config has been frozen</exception>
+    public CustomAdapterProvider<TCommonInterface, TAdapter> CustomAdapter<TCommonInterface, TAdapter>()
+        where TCommonInterface : class where TAdapter : class, ICustomAdapter<TAdapter, TCommonInterface>, IPolyType
+    {
+        CheckFrozen();
+        if (AdapterProviders.OfType<CustomAdapterProvider<TCommonInterface, TAdapter>>().SingleOrDefault() is { } adapter) return adapter;
+        adapter = new CustomAdapterProvider<TCommonInterface, TAdapter>(this);
+        AdapterProviders.Add(adapter);
+        return adapter;
+    }
+
+    internal IObjectBase Adapt(object obj)
+    {
+        if (AdapterProviders is [{ } defaultAdapter])
+        {
+            return defaultAdapter.Adapt(obj);
+        }
+
+        foreach (var objectAdapterProvider in AdapterProviders)
+        {
+            if (objectAdapterProvider.CanAdapt(obj))
+            {
+                return objectAdapterProvider.Adapt(obj);
+            }
+        }
+        throw new ArgumentException($"Unable to adapt object of type {obj.GetType()}");
+    }
+}

--- a/src/SIL.Harmony/Config/ObjectTypeListBuilder.cs
+++ b/src/SIL.Harmony/Config/ObjectTypeListBuilder.cs
@@ -13,7 +13,7 @@ public class ObjectTypeListBuilder
     /// <summary>
     /// we call freeze when the builder is used to create a json serializer options, as it is not possible to add new types after that.
     /// </summary>
-    public void Freeze()
+    internal void Freeze()
     {
         if (_frozen) return;
         _frozen = true;

--- a/src/SIL.Harmony/CrdtConfig.cs
+++ b/src/SIL.Harmony/CrdtConfig.cs
@@ -26,10 +26,7 @@ public class CrdtConfig
     /// </summary>
     public bool AlwaysValidateCommits { get; set; } = true;
     public ChangeTypeListBuilder ChangeTypeListBuilder { get; } = new();
-    public IEnumerable<RegisteredChangeType> ChangeTypes =>
-        ChangeTypeListBuilder.Types.Select(t => new RegisteredChangeType(
-            t.DerivedType,
-            (string)t.TypeDiscriminator!));
+    public IReadOnlyList<RegisteredChangeType> ChangeTypes => ChangeTypeListBuilder.Types;
     public ObjectTypeListBuilder ObjectTypeListBuilder { get; } = new();
     public IEnumerable<Type> ObjectTypes => ObjectTypeListBuilder.AdapterProviders.SelectMany(p => p.GetRegistrations().Select(r => r.ObjectDbType));
     public JsonSerializerOptions JsonSerializerOptions => _lazyJsonSerializerOptions.Value;
@@ -72,14 +69,10 @@ public class CrdtConfig
 
         var knownChanges = new Dictionary<string, Type>(ChangeTypeListBuilder.Types.Count);
         var discriminators = new Dictionary<Type, string>(ChangeTypeListBuilder.Types.Count);
-        foreach (var derived in ChangeTypeListBuilder.Types)
+        foreach (var changeType in ChangeTypeListBuilder.Types)
         {
-            if (derived.TypeDiscriminator is not string discriminator)
-                throw new InvalidOperationException(
-                    $"Change type {derived.DerivedType} must use a string $type discriminator");
-
-            knownChanges.Add(discriminator, derived.DerivedType);
-            discriminators.Add(derived.DerivedType, discriminator);
+            knownChanges.Add(changeType.Discriminator, changeType.Type);
+            discriminators.Add(changeType.Type, changeType.Discriminator);
         }
 
         return new ChangeDiscriminatorMaps(knownChanges, discriminators);
@@ -216,13 +209,14 @@ public class ChangeTypeListBuilder
     {
         if (_frozen) throw new InvalidOperationException($"{nameof(ChangeTypeListBuilder)} is frozen");
     }
-    internal List<JsonDerivedType> Types { get; } = [];
+    private readonly List<RegisteredChangeType> _types = [];
+    public IReadOnlyList<RegisteredChangeType> Types => _types.AsReadOnly();
 
     public ChangeTypeListBuilder Add<TDerived>() where TDerived : IChange, IPolyType
     {
         CheckFrozen();
-        if (Types.Any(t => t.DerivedType == typeof(TDerived))) return this;
-        Types.Add(new JsonDerivedType(typeof(TDerived), TDerived.TypeName));
+        if (_types.Any(t => t.Type == typeof(TDerived))) return this;
+        _types.Add(new RegisteredChangeType(typeof(TDerived), TDerived.TypeName));
         return this;
     }
 }

--- a/src/SIL.Harmony/CrdtConfig.cs
+++ b/src/SIL.Harmony/CrdtConfig.cs
@@ -11,6 +11,8 @@ namespace SIL.Harmony;
 
 public delegate ValueTask BeforeSaveObjectDelegate(object obj, ObjectSnapshot snapshot);
 
+public readonly record struct RegisteredChangeType(Type Type, string Discriminator);
+
 public class CrdtConfig
 {
     /// <summary>
@@ -24,10 +26,14 @@ public class CrdtConfig
     /// </summary>
     public bool AlwaysValidateCommits { get; set; } = true;
     public ChangeTypeListBuilder ChangeTypeListBuilder { get; } = new();
-    public IEnumerable<Type> ChangeTypes => ChangeTypeListBuilder.Types.Select(t => t.DerivedType);
+    public IEnumerable<RegisteredChangeType> ChangeTypes =>
+        ChangeTypeListBuilder.Types.Select(t => new RegisteredChangeType(
+            t.DerivedType,
+            (string)t.TypeDiscriminator!));
     public ObjectTypeListBuilder ObjectTypeListBuilder { get; } = new();
     public IEnumerable<Type> ObjectTypes => ObjectTypeListBuilder.AdapterProviders.SelectMany(p => p.GetRegistrations().Select(r => r.ObjectDbType));
     public JsonSerializerOptions JsonSerializerOptions => _lazyJsonSerializerOptions.Value;
+    private readonly JsonOptionsBuilder _jsonOptionsBuilder = new();
     private readonly Lazy<JsonSerializerOptions> _lazyJsonSerializerOptions;
     private readonly Lazy<ChangeDiscriminatorMaps> _lazyChangeDiscriminatorMaps;
 
@@ -46,7 +52,18 @@ public class CrdtConfig
             TypeInfoResolver = MakeJsonTypeResolver()
         };
         options.Converters.Add(new PeekThenConcreteChangeConverter(changeDiscriminators.ByDiscriminator));
+        _jsonOptionsBuilder.ApplyTo(options);
         return options;
+    }
+
+    /// <summary>
+    /// Registers a callback to customize <see cref="JsonSerializerOptions"/> before they are frozen.
+    /// Callbacks run after Harmony's type resolver and change converter are configured.
+    /// Replacing <see cref="JsonSerializerOptions.TypeInfoResolver"/> or removing the change converter will break serialization.
+    /// </summary>
+    public void ConfigureJsonOptions(Action<JsonSerializerOptions> configure)
+    {
+        _jsonOptionsBuilder.Configure(configure);
     }
 
     private ChangeDiscriminatorMaps BuildChangeDiscriminatorMaps()
@@ -154,6 +171,32 @@ public class CrdtConfig
             entity.HasKey(lr => lr.Id);
             entity.Property(lr => lr.LocalPath);
         });
+    }
+}
+
+internal class JsonOptionsBuilder
+{
+    private bool _frozen;
+    private readonly List<Action<JsonSerializerOptions>> _configurations = [];
+
+    public void Configure(Action<JsonSerializerOptions> configure)
+    {
+        CheckFrozen();
+        _configurations.Add(configure);
+    }
+
+    internal void ApplyTo(JsonSerializerOptions options)
+    {
+        foreach (var configure in _configurations)
+            configure(options);
+        Freeze();
+    }
+
+    private void Freeze() => _frozen = true;
+
+    private void CheckFrozen()
+    {
+        if (_frozen) throw new InvalidOperationException($"{nameof(JsonOptionsBuilder)} is frozen");
     }
 }
 

--- a/src/SIL.Harmony/CrdtKernel.cs
+++ b/src/SIL.Harmony/CrdtKernel.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 
 namespace SIL.Harmony;
@@ -10,7 +11,7 @@ namespace SIL.Harmony;
 public static class CrdtKernel
 {
     public static IServiceCollection AddCrdtDataDbFactory<TContext>(this IServiceCollection services,
-        Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
+        Action<HarmonyConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
         services.AddCrdtDataCore(configureCrdt);
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextFactory<TContext>>();
@@ -18,7 +19,7 @@ public static class CrdtKernel
     }
 
     public static IServiceCollection AddCrdtData<TContext>(this IServiceCollection services,
-        Action<CrdtConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
+        Action<HarmonyConfig> configureCrdt) where TContext : DbContext, ICrdtDbContext
     {
         services.AddCrdtDataCore(configureCrdt);
         services.AddScoped<ICrdtDbContextFactory, CrdtDbContextNoDisposeFactory<TContext>>();
@@ -26,29 +27,29 @@ public static class CrdtKernel
     }
 
     public static IServiceCollection AddCrdtRemoteResources<TMetadata>(this IServiceCollection services,
-        Action<CrdtConfig>? configureCrdt = null, string? cachePath = null)
+        Action<HarmonyConfig>? configureCrdt = null, string? cachePath = null)
         where TMetadata : class
     {
-        services.Configure<CrdtConfig>(config =>
+        services.Configure<HarmonyConfig>(config =>
         {
             config.AddRemoteResourceEntity<TMetadata>(cachePath);
             configureCrdt?.Invoke(config);
         });
         services.AddScoped<ResourceService<TMetadata>>(provider => new ResourceService<TMetadata>(
             provider.GetRequiredService<CrdtRepositoryFactory>(),
-            provider.GetRequiredService<IOptions<CrdtConfig>>(),
+            provider.GetRequiredService<IOptions<HarmonyConfig>>(),
             provider.GetRequiredService<DataModel>(),
             provider.GetRequiredService<ILogger<ResourceService<TMetadata>>>()
         ));
         return services;
     }
 
-    public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<CrdtConfig> configureCrdt)
+    public static IServiceCollection AddCrdtDataCore(this IServiceCollection services, Action<HarmonyConfig> configureCrdt)
     {
         services.AddLogging();
-        services.AddOptions<CrdtConfig>().Configure(configureCrdt)
+        services.AddOptions<HarmonyConfig>().Configure(configureCrdt)
             .PostConfigure(crdtConfig => crdtConfig.ObjectTypeListBuilder.Freeze());
-        services.AddSingleton(sp => sp.GetRequiredService<IOptions<CrdtConfig>>().Value.JsonSerializerOptions);
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<HarmonyConfig>>().Value.JsonSerializerOptions);
         services.AddSingleton(TimeProvider.System);
         services.AddScoped<IHybridDateTimeProvider>(NewTimeProvider);
         services.AddScoped<CrdtRepositoryFactory>();
@@ -57,7 +58,7 @@ public static class CrdtKernel
             provider.GetRequiredService<CrdtRepositoryFactory>(),
             provider.GetRequiredService<JsonSerializerOptions>(),
             provider.GetRequiredService<IHybridDateTimeProvider>(),
-            provider.GetRequiredService<IOptions<CrdtConfig>>(),
+            provider.GetRequiredService<IOptions<HarmonyConfig>>(),
             provider.GetRequiredService<ILogger<DataModel>>()
         ));
         return services;

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.AsyncEx;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 
 namespace SIL.Harmony;
@@ -21,14 +22,14 @@ public class DataModel : ISyncable, IAsyncDisposable
     private readonly CrdtRepositoryFactory _crdtRepositoryFactory;
     private readonly JsonSerializerOptions _serializerOptions;
     private readonly IHybridDateTimeProvider _timeProvider;
-    private readonly IOptions<CrdtConfig> _crdtConfig;
+    private readonly IOptions<HarmonyConfig> _crdtConfig;
     private readonly ILogger<DataModel> _logger;
 
     //constructor must be internal because CrdtRepository is internal
     internal DataModel(CrdtRepositoryFactory crdtRepositoryFactory,
         JsonSerializerOptions serializerOptions,
         IHybridDateTimeProvider timeProvider,
-        IOptions<CrdtConfig> crdtConfig,
+        IOptions<HarmonyConfig> crdtConfig,
         ILogger<DataModel> logger)
     {
         _crdtRepositoryFactory = crdtRepositoryFactory;

--- a/src/SIL.Harmony/Db/CrdtDbContextOptionsExtensions.cs
+++ b/src/SIL.Harmony/Db/CrdtDbContextOptionsExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db.EntityConfig;
 
 namespace SIL.Harmony.Db;
@@ -6,7 +7,7 @@ namespace SIL.Harmony.Db;
 public static class CrdtDbContextModelExtensions
 {
     public static ModelBuilder UseCrdt(this ModelBuilder modelBuilder,
-        CrdtConfig crdtConfig)
+        HarmonyConfig crdtConfig)
     {
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(CommitEntityConfig).Assembly)
             .ApplyConfiguration(new SnapshotEntityConfig(crdtConfig.JsonSerializerOptions))

--- a/src/SIL.Harmony/Db/CrdtRepository.cs
+++ b/src/SIL.Harmony/Db/CrdtRepository.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nito.AsyncEx;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Resource;
 
 namespace SIL.Harmony.Db;
@@ -49,10 +50,10 @@ internal class CrdtRepository : IDisposable, IAsyncDisposable
 
     private readonly AsyncLock _lock;
     private readonly ICrdtDbContext _dbContext;
-    private readonly IOptions<CrdtConfig> _crdtConfig;
+    private readonly IOptions<HarmonyConfig> _crdtConfig;
     private readonly ILogger<CrdtRepository> _logger;
 
-    public CrdtRepository(ICrdtDbContext dbContext, IOptions<CrdtConfig> crdtConfig,
+    public CrdtRepository(ICrdtDbContext dbContext, IOptions<HarmonyConfig> crdtConfig,
         ILogger<CrdtRepository> logger,
         Commit? ignoreChangesAfter = null)
     {

--- a/src/SIL.Harmony/ResourceService.cs
+++ b/src/SIL.Harmony/ResourceService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 using SIL.Harmony.Helpers;
 using SIL.Harmony.Resource;
@@ -11,11 +12,11 @@ namespace SIL.Harmony;
 public class ResourceService<TMetadata> where TMetadata : class
 {
     private readonly CrdtRepositoryFactory _crdtRepositoryFactory;
-    private readonly IOptions<CrdtConfig> _crdtConfig;
+    private readonly IOptions<HarmonyConfig> _crdtConfig;
     private readonly DataModel _dataModel;
     private readonly ILogger<ResourceService<TMetadata>> _logger;
 
-    internal ResourceService(CrdtRepositoryFactory crdtRepositoryFactory, IOptions<CrdtConfig> crdtConfig,
+    internal ResourceService(CrdtRepositoryFactory crdtRepositoryFactory, IOptions<HarmonyConfig> crdtConfig,
         DataModel dataModel, ILogger<ResourceService<TMetadata>> logger)
     {
         _crdtRepositoryFactory = crdtRepositoryFactory;

--- a/src/SIL.Harmony/SnapshotWorker.cs
+++ b/src/SIL.Harmony/SnapshotWorker.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Db;
 
 namespace SIL.Harmony;
@@ -12,7 +13,7 @@ internal class SnapshotWorker
 {
     private readonly Dictionary<Guid, Guid?> _snapshotLookup;
     private readonly CrdtRepository _crdtRepository;
-    private readonly CrdtConfig _crdtConfig;
+    private readonly HarmonyConfig _crdtConfig;
     private readonly Dictionary<Guid, ObjectSnapshot> _pendingSnapshots = [];
     private readonly Dictionary<Guid, ObjectSnapshot> _rootSnapshots = [];
     private readonly List<ObjectSnapshot> _newIntermediateSnapshots = [];
@@ -20,7 +21,7 @@ internal class SnapshotWorker
     private SnapshotWorker(Dictionary<Guid, ObjectSnapshot> snapshots,
         Dictionary<Guid, Guid?> snapshotLookup,
         CrdtRepository crdtRepository,
-        CrdtConfig crdtConfig)
+        HarmonyConfig crdtConfig)
     {
         _pendingSnapshots = snapshots;
         _crdtRepository = crdtRepository;
@@ -32,7 +33,7 @@ internal class SnapshotWorker
         Dictionary<Guid, ObjectSnapshot> snapshots,
         CrdtRepository crdtRepository,
         SortedSet<Commit> commits,
-        CrdtConfig crdtConfig)
+        HarmonyConfig crdtConfig)
     {
         //we need to pass in the snapshots because we expect it to be modified, this is intended.
         //if the constructor makes a copy in the future this will need to be updated
@@ -45,7 +46,7 @@ internal class SnapshotWorker
     /// <param name="crdtConfig"></param>
     internal SnapshotWorker(Dictionary<Guid, Guid?> snapshotLookup,
         CrdtRepository crdtRepository,
-        CrdtConfig crdtConfig) : this([], snapshotLookup, crdtRepository, crdtConfig)
+        HarmonyConfig crdtConfig) : this([], snapshotLookup, crdtRepository, crdtConfig)
     {
     }
 


### PR DESCRIPTION
Now clients don't need to do any weird workarounds to tweak json options. HarmonyConfig now exposes `RegisteredChangeType` for types so clients can easily get the change discriminator without hacking around using reflection and stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a formal change-type registration system with string discriminators (including support for deletes).
  * Added `ConfigureJsonOptions` for polymorphic JSON behavior, with cumulative callbacks and a safe “frozen” enforcement.
  * Introduced object/adapters registration and projected-table adaptation capabilities for custom interfaces.
* **Refactor**
  * Consolidated configuration under `HarmonyConfig` (replacing the prior configuration model) across database, repository, snapshots, and resources.
* **Tests**
  * Expanded tests for change-type registration/discriminator expectations and JSON option configuration/freezing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->