### PR TITLE
add parameterless constructor to ServerCommit

### DIFF
--- a/src/SIL.Harmony.Core/CommitBase.cs
+++ b/src/SIL.Harmony.Core/CommitBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Hashing;
 using System.Text.Json.Serialization;
 
@@ -11,6 +12,7 @@ public abstract class CommitBase : IComparable<CommitBase>
 {
     public const string NullParentHash = "0000";
     [JsonConstructor]
+    [SetsRequiredMembers]
     protected internal CommitBase(Guid id, HybridDateTime hybridDateTime)
     {
         Id = id;
@@ -56,6 +58,7 @@ public abstract class CommitBase : IComparable<CommitBase>
 /// <inheritdoc cref="CommitBase"/>
 public abstract class CommitBase<TChange> : CommitBase
 {
+    [SetsRequiredMembers]
     internal CommitBase(Guid id, HybridDateTime hybridDateTime) : base(id, hybridDateTime)
     {
     }

--- a/src/SIL.Harmony.Core/ServerCommit.cs
+++ b/src/SIL.Harmony.Core/ServerCommit.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -7,12 +8,18 @@ namespace SIL.Harmony.Core;
 public class ServerCommit : CommitBase<ServerJsonChange>
 {
     [JsonConstructor]
+    [SetsRequiredMembers]
     protected ServerCommit(Guid id, HybridDateTime hybridDateTime) : base(id,
         hybridDateTime)
     {
     }
 
     public ServerCommit(Guid id) : base(id)
+    {
+    }
+
+    //only here for a downstream gql issue
+    private ServerCommit() : base(Guid.NewGuid())
     {
     }
 

--- a/src/SIL.Harmony/Commit.cs
+++ b/src/SIL.Harmony/Commit.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using SIL.Harmony.Changes;
 using SIL.Harmony.Db;
@@ -7,6 +8,7 @@ namespace SIL.Harmony;
 public class Commit : CommitBase<IChange>
 {
     [JsonConstructor]
+    [SetsRequiredMembers]
     protected Commit(Guid id, string hash, string parentHash, HybridDateTime hybridDateTime) : base(id,
         hybridDateTime)
     {


### PR DESCRIPTION
required to use in gql in lexbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit deserialization and initialization reliability.
  * Ensured commit instances receive valid identifiers when reconstructed from stored or remote data.
  * Resolved required-member initialization warnings during commit creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->