### PR TITLE
[claude] Run snapshot regeneration in a transaction

### DIFF
--- a/src/SIL.Harmony.Tests/SnapshotTests.cs
+++ b/src/SIL.Harmony.Tests/SnapshotTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Config;
 using SIL.Harmony.Sample.Changes;
 using SIL.Harmony.Sample.Models;
 
@@ -171,5 +174,25 @@ public class SnapshotTests : DataModelTestBase
 
         //we probably won't have the same number of snapshots, which is ok. but none of the ids should be the same
         afterSnapshotsIds.Should().NotIntersectWith(beforeSnapshotIds);
+    }
+
+    [Fact]
+    public async Task RegenerateSnapshots_LeavesTheProjectIntactWhenTheRebuildFails()
+    {
+        var entityId = Guid.NewGuid();
+        await WriteNextChange(SetWord(entityId, "test root"));
+        await WriteNextChange(SetWord(entityId, "test1"));
+        var beforeSnapshotIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync(TestContext.Current.CancellationToken);
+        var beforeRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync(TestContext.Current.CancellationToken);
+
+        _services.GetRequiredService<IOptions<HarmonyConfig>>().Value.BeforeSaveObject =
+            (_, _) => throw new InvalidOperationException("rebuild failed");
+        Func<Task> act = () => DataModel.RegenerateSnapshots();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        var afterSnapshotIds = await DbContext.Snapshots.Select(s => s.Id).ToArrayAsync(TestContext.Current.CancellationToken);
+        afterSnapshotIds.Should().BeEquivalentTo(beforeSnapshotIds);
+        var afterRegenerate = await DataModel.QueryLatest<Word>().ToArrayAsync(TestContext.Current.CancellationToken);
+        afterRegenerate.Should().BeEquivalentTo(beforeRegenerate);
     }
 }

--- a/src/SIL.Harmony/DataModel.cs
+++ b/src/SIL.Harmony/DataModel.cs
@@ -234,12 +234,15 @@ public class DataModel : ISyncable, IAsyncDisposable
     public async Task RegenerateSnapshots()
     {
         await using var repo = await _crdtRepositoryFactory.CreateRepository();
-        await repo.DeleteSnapshotsAndProjectedTables();
+        using var locked = await repo.Lock();
         repo.ClearChangeTracker();
+        await using var transaction = await repo.BeginTransactionAsync();
+        await repo.DeleteSnapshotsAndProjectedTables();
         var allCommits = await repo.CurrentCommits()
             .Include(c => c.ChangeEntities)
             .ToSortedSetAsync();
         await UpdateSnapshots(repo, allCommits);
+        await transaction.CommitAsync();
     }
 
     public async Task<ObjectSnapshot> GetLatestSnapshotByObjectId(Guid entityId)


### PR DESCRIPTION
*[Claude, autonomous]*

`RegenerateSnapshots` deleted every snapshot and projected row with `ExecuteDelete` (which auto-commits) before rebuilding from history, so a failure part way through left the project with nothing to read. It now takes the repo lock and commits the delete plus rebuild as one transaction, like the other mutating paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Snapshot regeneration now safely rolls back when rebuilding fails, preserving existing snapshots and word data.
  - Regeneration operations are performed transactionally to prevent partial updates and maintain project integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->